### PR TITLE
Fix: Resolve failing tests in GeneticAlgorithm

### DIFF
--- a/src/genetic_algorithm.cpp
+++ b/src/genetic_algorithm.cpp
@@ -34,6 +34,7 @@ GeneticAlgorithm::GeneticAlgorithm(
       crossover_rate_(crossover_rate),
       num_generations_(num_generations),
       template_network_(template_network), // Make a copy of the template network
+      best_individual_(template_network), // Initialize best_individual_ with template structure
       best_fitness_score_(std::numeric_limits<double>::lowest()) { // Initialize best score to a very low value
     
     // Seed the random number generator for reproducibility during a run,

--- a/src/neuronet.cpp
+++ b/src/neuronet.cpp
@@ -253,11 +253,41 @@ Matrix::Matrix<float> NeuroNet::NeuroNet::GetOutput() {
 // For Doxygen, their detailed comments are in the header.
 
 NeuroNet::LayerWeights NeuroNet::NeuroNetLayer::get_weights() const {
-	return this->Weights;
+    LayerWeights current_weights_struct;
+    // Use the WeightCount already stored in this->Weights, which ResizeLayer correctly sets.
+    current_weights_struct.WeightCount = this->Weights.WeightCount; 
+    if (this->WeightMatrix.rows() * this->WeightMatrix.cols() != current_weights_struct.WeightCount) {
+        // Optional: Add error handling or log if counts mismatch,
+        // but this->Weights.WeightCount should be authoritative if ResizeLayer is always used.
+    }
+
+    current_weights_struct.WeightsVector.clear(); // Ensure vector is empty before filling
+    current_weights_struct.WeightsVector.reserve(current_weights_struct.WeightCount);
+
+    for (int i = 0; i < this->WeightMatrix.rows(); ++i) {
+        for (int j = 0; j < this->WeightMatrix.cols(); ++j) {
+            current_weights_struct.WeightsVector.push_back(this->WeightMatrix[i][j]);
+        }
+    }
+    return current_weights_struct;
 }
 
 NeuroNet::LayerBiases NeuroNet::NeuroNetLayer::get_biases() const {
-	return this->Biases;
+    LayerBiases current_biases_struct;
+    // Use the BiasCount already stored in this->Biases, which ResizeLayer correctly sets.
+    current_biases_struct.BiasCount = this->Biases.BiasCount;
+    if (this->BiasMatrix.cols() != current_biases_struct.BiasCount && this->BiasMatrix.rows() == 1) {
+         // Optional: Add error handling or log if counts mismatch
+    }
+
+    current_biases_struct.BiasVector.clear(); // Ensure vector is empty before filling
+    current_biases_struct.BiasVector.reserve(current_biases_struct.BiasCount);
+
+    // BiasMatrix is 1xN (1 row, N columns where N is number of neurons/biases)
+    for (int j = 0; j < this->BiasMatrix.cols(); ++j) {
+        current_biases_struct.BiasVector.push_back(this->BiasMatrix[0][j]);
+    }
+    return current_biases_struct;
 }
 
 // --- Helper Method Implementations for NeuroNet ---


### PR DESCRIPTION
The GeneticAlgorithmTest.EvaluateFitness and
GeneticAlgorithmTest.GetBestIndividual tests were failing because the best individuals reported by the genetic algorithm had no weights (weights vector size was 0).

This was caused by two issues:
1. The NeuroNetLayer::get_weights() and get_biases() methods returned LayerWeights/LayerBiases structs whose internal vectors (WeightsVector, BiasVector) were not populated with data from the layer's actual WeightMatrix and BiasMatrix. These vectors were cleared during layer resizing and only repopulated if SetWeights/SetBiases was explicitly called. This meant NeuroNet::get_all_weights_flat() returned an empty vector.
2. The GeneticAlgorithm's create_random_individual method relied on get_all_weights_flat() to get the initial set of weights to randomize. Since this was empty, individuals were effectively initialized without weights in their matrices.

The fix involved:
- Modifying NeuroNetLayer::get_weights() and get_biases() to construct and return new structs populated with data directly from the WeightMatrix and BiasMatrix.
- As a precaution, best_individual_ in the GeneticAlgorithm constructor was also initialized using the template_network to ensure it starts with a valid structure, though the primary issue was in NeuroNetLayer.

With these changes, individuals in the genetic algorithm are correctly initialized with weights, and all tests now pass.