### PR TITLE
Fix PR issues (Softmax backprop, JSON unicode, multiline strings)

### DIFF
--- a/examples/transformer_usage.cpp
+++ b/examples/transformer_usage.cpp
@@ -37,48 +37,29 @@ bool create_dummy_vocab_file(const std::string& filepath, int vocab_size, int& p
         std::cerr << "ERROR: Failed to create dummy vocabulary file at " << filepath << std::endl;
         return false;
     }
-    vocab_file << "{
-";
-    vocab_file << "  \"word_to_token\": {
-";
+    vocab_file << "{\n";
+    vocab_file << "  \"word_to_token\": {\n";
     for (int i = 0; i < vocab_size - 2; ++i) {
-        vocab_file << "    \"token" << i << "\": " << i << (i == vocab_size - 3 ? "" : ",") << "
-";
+        vocab_file << "    \"token" << i << "\": " << i << (i == vocab_size - 3 ? "" : ",") << "\n";
     }
-    vocab_file << "    \"<UNK>\": " << unk_id << ",
-";
-    vocab_file << "    \"<PAD>\": " << pad_id << "
-";
-    vocab_file << "  },
-";
-    vocab_file << "  \"token_to_word\": {
-";
+    vocab_file << "    \"<UNK>\": " << unk_id << ",\n";
+    vocab_file << "    \"<PAD>\": " << pad_id << "\n";
+    vocab_file << "  },\n";
+    vocab_file << "  \"token_to_word\": {\n";
     for (int i = 0; i < vocab_size - 2; ++i) {
-        vocab_file << "    \"" << i << "\": \"token" << i << "\",
-";
+        vocab_file << "    \"" << i << "\": \"token" << i << "\",\n";
     }
-    vocab_file << "    \"" << unk_id << "\": \"<UNK>\",
-";
-    vocab_file << "    \"" << pad_id << "\": \"<PAD>\"
-";
-    vocab_file << "  },
-";
-    vocab_file << "  \"special_tokens\": {
-";
-    vocab_file << "    \"unknown_token\": \"<UNK>\",
-";
-    vocab_file << "    \"padding_token\": \"<PAD>\"
-";
-    vocab_file << "  },
-";
-    vocab_file << "  \"config\": {
-";
-    vocab_file << "    \"max_sequence_length\": 10
-"; // Default max_seq_len for vocab
-    vocab_file << "  }
-";
-    vocab_file << "}
-";
+    vocab_file << "    \"" << unk_id << "\": \"<UNK>\",\n";
+    vocab_file << "    \"" << pad_id << "\": \"<PAD>\"\n";
+    vocab_file << "  },\n";
+    vocab_file << "  \"special_tokens\": {\n";
+    vocab_file << "    \"unknown_token\": \"<UNK>\",\n";
+    vocab_file << "    \"padding_token\": \"<PAD>\"\n";
+    vocab_file << "  },\n";
+    vocab_file << "  \"config\": {\n";
+    vocab_file << "    \"max_sequence_length\": 10\n"; // Default max_seq_len for vocab
+    vocab_file << "  }\n";
+    vocab_file << "}\n";
     vocab_file.close();
     std::cout << "Dummy vocabulary file created: " << filepath << std::endl;
     return true;
@@ -107,8 +88,7 @@ int main() {
         vocab_size_param, max_seq_len_param, d_model_param,
         num_encoder_layers_param, num_heads_param, d_ff_param
     );
-    std::cout << "
-1. TransformerModel instantiated." << std::endl;
+    std::cout << "\n1. TransformerModel instantiated." << std::endl;
     std::cout << "   Vocab Size: " << model.get_vocab_size() << std::endl;
     std::cout << "   Max Seq Len: " << model.get_max_seq_len() << std::endl;
     std::cout << "   D_Model: " << model.get_d_model() << std::endl;
@@ -123,8 +103,7 @@ int main() {
         std::remove(vocab_filepath.c_str()); // Clean up
         return 1;
     }
-    std::cout << "
-2. Vocabulary loaded from " << vocab_filepath << "." << std::endl;
+    std::cout << "\n2. Vocabulary loaded from " << vocab_filepath << "." << std::endl;
     std::cout << "   Vocab max_seq_len (from file): " << vocab.get_max_sequence_length() << std::endl;
     std::cout << "   Padding token ID: " << vocab.get_padding_token_id() << std::endl;
 
@@ -133,8 +112,7 @@ int main() {
         "hello world token0 token1", // 4 tokens
         "token2 token3 unknownword"  // 3 tokens, "unknownword" -> <UNK>
     };
-    std::cout << "
-3. Processing string input batch:" << std::endl;
+    std::cout << "\n3. Processing string input batch:" << std::endl;
     for(const auto&s : text_batch) std::cout << "   \"" << s << "\"" << std::endl;
 
     // `prepare_batch_matrix` pads/truncates to `max_len`.
@@ -145,8 +123,7 @@ int main() {
 
 
     // --- 4. Forward Pass (one sequence at a time, as model.forward expects 1xN) ---
-    std::cout << "
-4. Performing forward pass (one sequence at a time):" << std::endl;
+    std::cout << "\n4. Performing forward pass (one sequence at a time):" << std::endl;
     if (token_id_batch_matrix.rows() > 0) {
         for (size_t i = 0; i < token_id_batch_matrix.rows(); ++i) {
             // Create a (1, seq_len) matrix for the current sequence
@@ -173,14 +150,12 @@ int main() {
 
 
     // --- 5. Save Model ---
-    std::cout << "
-5. Saving model to " << model_save_filepath << "..." << std::endl;
+    std::cout << "\n5. Saving model to " << model_save_filepath << "..." << std::endl;
     if (model.save_model(model_save_filepath)) {
         std::cout << "   Model saved successfully." << std::endl;
 
         // --- 6. Load Model ---
-        std::cout << "
-6. Loading model from " << model_save_filepath << "..." << std::endl;
+        std::cout << "\n6. Loading model from " << model_save_filepath << "..." << std::endl;
         try {
             NeuroNet::Transformer::TransformerModel loaded_model = NeuroNet::Transformer::TransformerModel::load_model(model_save_filepath);
             std::cout << "   Model loaded successfully." << std::endl;
@@ -212,9 +187,7 @@ int main() {
 
     // --- Cleanup ---
     std::remove(vocab_filepath.c_str()); // Clean up dummy vocab file
-    std::cout << "
-Cleaned up temporary vocabulary file: " << vocab_filepath << std::endl;
-    std::cout << "
---- Example Finished ---" << std::endl;
+    std::cout << "\nCleaned up temporary vocabulary file: " << vocab_filepath << std::endl;
+    std::cout << "\n--- Example Finished ---" << std::endl;
     return 0;
 }

--- a/src/neural_network/neuronet.cpp
+++ b/src/neural_network/neuronet.cpp
@@ -425,7 +425,8 @@ Matrix::Matrix<float> NeuroNet::NeuroNetLayer::BackwardPass(const Matrix::Matrix
                 dAdZ.resize(this->OutputMatrix.rows(), this->OutputMatrix.cols());
                 dAdZ.assign(1.0f);
             } else {
-                dAdZ = DerivativeSoftmax(this->OutputMatrix);
+                // We don't use dAdZ for Softmax when not last layer, because it requires the full Jacobian.
+                // We will compute dLdZ directly to handle the Jacobian below.
             }
             break;
         case ActivationFunctionType::None:
@@ -442,17 +443,31 @@ Matrix::Matrix<float> NeuroNet::NeuroNetLayer::BackwardPass(const Matrix::Matrix
             break;
     }
 
-    // dLdActivationInput (dLdZ) = dLdOutput (dLdA) element-wise_multiply dAdZ
     Matrix::Matrix<float> dLdZ = dLdOutput; // Copy dimensions
-    if (dLdOutput.rows() != dAdZ.rows() || dLdOutput.cols() != dAdZ.cols()) {
-        // Error handling: dimensions must match for element-wise product
-        throw std::runtime_error("Dimension mismatch for element-wise multiplication in BackwardPass (dLdOutput vs dAdZ). "
-                                 "dLdOutput: (" + std::to_string(dLdOutput.rows()) + "," + std::to_string(dLdOutput.cols()) + ") "
-                                 "dAdZ: (" + std::to_string(dAdZ.rows()) + "," + std::to_string(dAdZ.cols()) + ")");
-    }
-    for (int i = 0; i < dLdZ.rows(); ++i) {
-        for (int j = 0; j < dLdZ.cols(); ++j) {
-            dLdZ[i][j] = dLdOutput[i][j] * dAdZ[i][j];
+    if (this->vActivationFunction == ActivationFunctionType::Softmax && !is_last_layer) {
+        // Compute dLdZ directly using the Softmax Jacobian:
+        // dL/dZ_i = S_i * (dL/dA_i - sum_j (dL/dA_j * S_j))
+        for (int i = 0; i < dLdZ.rows(); ++i) {
+            float sum_da_s = 0.0f;
+            for (int j = 0; j < dLdZ.cols(); ++j) {
+                sum_da_s += dLdOutput[i][j] * this->OutputMatrix[i][j];
+            }
+            for (int j = 0; j < dLdZ.cols(); ++j) {
+                dLdZ[i][j] = this->OutputMatrix[i][j] * (dLdOutput[i][j] - sum_da_s);
+            }
+        }
+    } else {
+        // dLdActivationInput (dLdZ) = dLdOutput (dLdA) element-wise_multiply dAdZ
+        if (dLdOutput.rows() != dAdZ.rows() || dLdOutput.cols() != dAdZ.cols()) {
+            // Error handling: dimensions must match for element-wise product
+            throw std::runtime_error("Dimension mismatch for element-wise multiplication in BackwardPass (dLdOutput vs dAdZ). "
+                                     "dLdOutput: (" + std::to_string(dLdOutput.rows()) + "," + std::to_string(dLdOutput.cols()) + ") "
+                                     "dAdZ: (" + std::to_string(dAdZ.rows()) + "," + std::to_string(dAdZ.cols()) + ")");
+        }
+        for (int i = 0; i < dLdZ.rows(); ++i) {
+            for (int j = 0; j < dLdZ.cols(); ++j) {
+                dLdZ[i][j] = dLdOutput[i][j] * dAdZ[i][j];
+            }
         }
     }
 

--- a/src/neural_network/neuronet.cpp
+++ b/src/neural_network/neuronet.cpp
@@ -418,11 +418,11 @@ Matrix::Matrix<float> NeuroNet::NeuroNetLayer::BackwardPass(const Matrix::Matrix
             break;
         case ActivationFunctionType::Softmax:
             // For Softmax with Cross-Entropy loss, dL/dZ = A - Y (output - target).
-            // If dLdOutput *is* already (A-Y) for the output layer, then dLdActivationInput = dLdOutput.
-            // But the plan is generic. dLdOutput is dL/dA.
-            // dL/dZ_i = sum_j (dL/dA_j * dA_j/dZ_i).
-            // If using the simplified S_i(1-S_i) from DerivativeSoftmax:
-            dAdZ = DerivativeSoftmax(this->OutputMatrix);
+            // Since NeuroNet::Backpropagate seeds dLdOutput with (A - Y),
+            // dLdOutput is already dL/dZ. We just return a matrix of ones for dAdZ
+            // so that dLdActivationInput = dLdOutput * 1 = (A - Y).
+            dAdZ.resize(this->OutputMatrix.rows(), this->OutputMatrix.cols());
+            dAdZ.assign(1.0f);
             break;
         case ActivationFunctionType::None:
             // If no activation, f(Z) = Z, so f'(Z) = 1.

--- a/src/neural_network/neuronet.cpp
+++ b/src/neural_network/neuronet.cpp
@@ -387,7 +387,7 @@ Matrix::Matrix<float> NeuroNet::NeuroNetLayer::DerivativeSoftmax(const Matrix::M
     return derivative;
 }
 
-Matrix::Matrix<float> NeuroNet::NeuroNetLayer::BackwardPass(const Matrix::Matrix<float>& dLdOutput, const Matrix::Matrix<float>& input_to_this_layer) {
+Matrix::Matrix<float> NeuroNet::NeuroNetLayer::BackwardPass(const Matrix::Matrix<float>& dLdOutput, const Matrix::Matrix<float>& input_to_this_layer, bool is_last_layer) {
     // Ensure gradient matrices are initialized/resized correctly
     // This check is a safeguard; ResizeLayer should have already initialized them.
     if (this->dLdW.rows() != this->WeightMatrix.rows() || this->dLdW.cols() != this->WeightMatrix.cols()) {
@@ -417,12 +417,16 @@ Matrix::Matrix<float> NeuroNet::NeuroNetLayer::BackwardPass(const Matrix::Matrix
             dAdZ = DerivativeELU(this->OutputMatrix);
             break;
         case ActivationFunctionType::Softmax:
-            // For Softmax with Cross-Entropy loss, dL/dZ = A - Y (output - target).
-            // Since NeuroNet::Backpropagate seeds dLdOutput with (A - Y),
-            // dLdOutput is already dL/dZ. We just return a matrix of ones for dAdZ
-            // so that dLdActivationInput = dLdOutput * 1 = (A - Y).
-            dAdZ.resize(this->OutputMatrix.rows(), this->OutputMatrix.cols());
-            dAdZ.assign(1.0f);
+            if (is_last_layer) {
+                // For Softmax with Cross-Entropy loss on the last layer, dL/dZ = A - Y (output - target).
+                // Since NeuroNet::Backpropagate seeds dLdOutput with (A - Y),
+                // dLdOutput is already dL/dZ. We just return a matrix of ones for dAdZ
+                // so that dLdActivationInput = dLdOutput * 1 = (A - Y).
+                dAdZ.resize(this->OutputMatrix.rows(), this->OutputMatrix.cols());
+                dAdZ.assign(1.0f);
+            } else {
+                dAdZ = DerivativeSoftmax(this->OutputMatrix);
+            }
             break;
         case ActivationFunctionType::None:
             // If no activation, f(Z) = Z, so f'(Z) = 1.
@@ -1053,7 +1057,8 @@ void NeuroNet::NeuroNet::Backpropagate(const Matrix::Matrix<float>& actual_outpu
         }
 
 
-        dLdOutput_current = current_layer.BackwardPass(dLdOutput_current, input_to_current_layer);
+        bool is_last = (i == this->LayerCount - 1);
+        dLdOutput_current = current_layer.BackwardPass(dLdOutput_current, input_to_current_layer, is_last);
         // The returned dLdOutput_current is now dL/dInput for the current layer,
         // which is dL/dOutput for the *previous* layer (i-1).
     }

--- a/src/neural_network/neuronet.h
+++ b/src/neural_network/neuronet.h
@@ -230,11 +230,13 @@ namespace NeuroNet
      *                  Dimensions should match this layer's output dimensions.
      * @param input_to_this_layer The input matrix that was fed to this layer during the forward pass (X, or A_prev).
      *                            Dimensions should match this layer's input dimensions.
+     * @param is_last_layer Boolean flag indicating if this is the final output layer of the network.
+     *                      Used for optimizing the backpropagation step for Softmax layers with CCE loss.
      * @return Matrix::Matrix<float> Gradient of the loss with respect to this layer's input (dL/dX_prev),
      *                               to be passed to the previous layer.
      * @throws std::runtime_error if dimension mismatches occur during calculations.
      */
-    Matrix::Matrix<float> BackwardPass(const Matrix::Matrix<float>& dLdOutput, const Matrix::Matrix<float>& input_to_this_layer);
+    Matrix::Matrix<float> BackwardPass(const Matrix::Matrix<float>& dLdOutput, const Matrix::Matrix<float>& input_to_this_layer, bool is_last_layer = false);
 
     /**
      * @brief Retrieves the stored gradient of the loss with respect to the layer's weights (dL/dW).

--- a/src/utilities/json/json.cpp
+++ b/src/utilities/json/json.cpp
@@ -164,16 +164,20 @@ std::string JsonParser::ParseString(const std::string& json_string, size_t& inde
 							throw JsonParseException("Unexpected end of string");
 						}
 						std::string hex_string = json_string.substr(index, 4);
+						size_t chars_processed = 0;
 						try
 						{
-							int code_point = std::stoi(hex_string, nullptr, 16);
+							int code_point = std::stoi(hex_string, &chars_processed, 16);
+							if (chars_processed != 4) {
+								throw JsonParseException("Invalid Unicode escape sequence");
+							}
 							result += UnicodeCodePointToUtf8(code_point);
 						}
 						catch (const std::invalid_argument& ex)
 						{
 							throw JsonParseException("Invalid Unicode escape sequence");
 						}
-						index +=4;
+						index += 3;
 						break;
 						}
 					default:

--- a/src/utilities/json/json.cpp
+++ b/src/utilities/json/json.cpp
@@ -164,6 +164,14 @@ std::string JsonParser::ParseString(const std::string& json_string, size_t& inde
 							throw JsonParseException("Unexpected end of string");
 						}
 						std::string hex_string = json_string.substr(index, 4);
+
+						// Verify all 4 characters are valid hex digits before attempting to parse
+						for (char c : hex_string) {
+							if (!std::isxdigit(static_cast<unsigned char>(c))) {
+								throw JsonParseException("Invalid Unicode escape sequence");
+							}
+						}
+
 						size_t chars_processed = 0;
 						try
 						{


### PR DESCRIPTION
* Avoid reapplying softmax derivative in backpropagation.
* Ensure valid JSON Unicode escape sequences and fix index advancement.
* Escape newlines correctly in `examples/transformer_usage.cpp`.

---
*PR created automatically by Jules for task [10944704568247764160](https://jules.google.com/task/10944704568247764160) started by @JacobBorden*