### PR TITLE
Fix outstanding PR comments on JSON parsing and Softmax Backprop

### DIFF
--- a/src/neural_network/neuronet.cpp
+++ b/src/neural_network/neuronet.cpp
@@ -425,7 +425,8 @@ Matrix::Matrix<float> NeuroNet::NeuroNetLayer::BackwardPass(const Matrix::Matrix
                 dAdZ.resize(this->OutputMatrix.rows(), this->OutputMatrix.cols());
                 dAdZ.assign(1.0f);
             } else {
-                dAdZ = DerivativeSoftmax(this->OutputMatrix);
+                // We don't use dAdZ for Softmax when not last layer, because it requires the full Jacobian.
+                // We will compute dLdZ directly to handle the Jacobian below.
             }
             break;
         case ActivationFunctionType::None:
@@ -442,17 +443,31 @@ Matrix::Matrix<float> NeuroNet::NeuroNetLayer::BackwardPass(const Matrix::Matrix
             break;
     }
 
-    // dLdActivationInput (dLdZ) = dLdOutput (dLdA) element-wise_multiply dAdZ
     Matrix::Matrix<float> dLdZ = dLdOutput; // Copy dimensions
-    if (dLdOutput.rows() != dAdZ.rows() || dLdOutput.cols() != dAdZ.cols()) {
-        // Error handling: dimensions must match for element-wise product
-        throw std::runtime_error("Dimension mismatch for element-wise multiplication in BackwardPass (dLdOutput vs dAdZ). "
-                                 "dLdOutput: (" + std::to_string(dLdOutput.rows()) + "," + std::to_string(dLdOutput.cols()) + ") "
-                                 "dAdZ: (" + std::to_string(dAdZ.rows()) + "," + std::to_string(dAdZ.cols()) + ")");
-    }
-    for (int i = 0; i < dLdZ.rows(); ++i) {
-        for (int j = 0; j < dLdZ.cols(); ++j) {
-            dLdZ[i][j] = dLdOutput[i][j] * dAdZ[i][j];
+    if (this->vActivationFunction == ActivationFunctionType::Softmax && !is_last_layer) {
+        // Compute dLdZ directly using the Softmax Jacobian:
+        // dL/dZ_i = S_i * (dL/dA_i - sum_j (dL/dA_j * S_j))
+        for (int i = 0; i < dLdZ.rows(); ++i) {
+            float sum_da_s = 0.0f;
+            for (int j = 0; j < dLdZ.cols(); ++j) {
+                sum_da_s += dLdOutput[i][j] * this->OutputMatrix[i][j];
+            }
+            for (int j = 0; j < dLdZ.cols(); ++j) {
+                dLdZ[i][j] = this->OutputMatrix[i][j] * (dLdOutput[i][j] - sum_da_s);
+            }
+        }
+    } else {
+        // dLdActivationInput (dLdZ) = dLdOutput (dLdA) element-wise_multiply dAdZ
+        if (dLdOutput.rows() != dAdZ.rows() || dLdOutput.cols() != dAdZ.cols()) {
+            // Error handling: dimensions must match for element-wise product
+            throw std::runtime_error("Dimension mismatch for element-wise multiplication in BackwardPass (dLdOutput vs dAdZ). "
+                                     "dLdOutput: (" + std::to_string(dLdOutput.rows()) + "," + std::to_string(dLdOutput.cols()) + ") "
+                                     "dAdZ: (" + std::to_string(dAdZ.rows()) + "," + std::to_string(dAdZ.cols()) + ")");
+        }
+        for (int i = 0; i < dLdZ.rows(); ++i) {
+            for (int j = 0; j < dLdZ.cols(); ++j) {
+                dLdZ[i][j] = dLdOutput[i][j] * dAdZ[i][j];
+            }
         }
     }
 

--- a/src/neural_network/neuronet.cpp
+++ b/src/neural_network/neuronet.cpp
@@ -387,7 +387,7 @@ Matrix::Matrix<float> NeuroNet::NeuroNetLayer::DerivativeSoftmax(const Matrix::M
     return derivative;
 }
 
-Matrix::Matrix<float> NeuroNet::NeuroNetLayer::BackwardPass(const Matrix::Matrix<float>& dLdOutput, const Matrix::Matrix<float>& input_to_this_layer) {
+Matrix::Matrix<float> NeuroNet::NeuroNetLayer::BackwardPass(const Matrix::Matrix<float>& dLdOutput, const Matrix::Matrix<float>& input_to_this_layer, bool is_last_layer) {
     // Ensure gradient matrices are initialized/resized correctly
     // This check is a safeguard; ResizeLayer should have already initialized them.
     if (this->dLdW.rows() != this->WeightMatrix.rows() || this->dLdW.cols() != this->WeightMatrix.cols()) {
@@ -417,12 +417,16 @@ Matrix::Matrix<float> NeuroNet::NeuroNetLayer::BackwardPass(const Matrix::Matrix
             dAdZ = DerivativeELU(this->OutputMatrix);
             break;
         case ActivationFunctionType::Softmax:
-            // For Softmax with Cross-Entropy loss, dL/dZ = A - Y (output - target).
-            // Since NeuroNet::Backpropagate seeds dLdOutput with (A - Y),
-            // dLdOutput is already dL/dZ. We just return a matrix of ones for dAdZ
-            // so that dLdActivationInput = dLdOutput * 1 = (A - Y).
-            dAdZ.resize(this->OutputMatrix.rows(), this->OutputMatrix.cols());
-            dAdZ.assign(1.0f);
+            if (is_last_layer) {
+                // For Softmax with Cross-Entropy loss on the last layer, dL/dZ = A - Y (output - target).
+                // Since NeuroNet::Backpropagate seeds dLdOutput with (A - Y),
+                // dLdOutput is already dL/dZ. We just return a matrix of ones for dAdZ
+                // so that dLdActivationInput = dLdOutput * 1 = (A - Y).
+                dAdZ.resize(this->OutputMatrix.rows(), this->OutputMatrix.cols());
+                dAdZ.assign(1.0f);
+            } else {
+                dAdZ = DerivativeSoftmax(this->OutputMatrix);
+            }
             break;
         case ActivationFunctionType::None:
             // If no activation, f(Z) = Z, so f'(Z) = 1.
@@ -1053,7 +1057,8 @@ void NeuroNet::NeuroNet::Backpropagate(const Matrix::Matrix<float>& actual_outpu
         }
 
 
-        dLdOutput_current = current_layer.BackwardPass(dLdOutput_current, input_to_current_layer);
+        bool is_last = (i == this->LayerCount - 1);
+        dLdOutput_current = current_layer.BackwardPass(dLdOutput_current, input_to_current_layer, is_last);
         // The returned dLdOutput_current is now dL/dInput for the current layer,
         // which is dL/dOutput for the *previous* layer (i-1).
     }

--- a/src/neural_network/neuronet.h
+++ b/src/neural_network/neuronet.h
@@ -230,11 +230,13 @@ namespace NeuroNet
      *                  Dimensions should match this layer's output dimensions.
      * @param input_to_this_layer The input matrix that was fed to this layer during the forward pass (X, or A_prev).
      *                            Dimensions should match this layer's input dimensions.
+     * @param is_last_layer Boolean flag indicating if this is the final output layer of the network.
+     *                      Used for optimizing the backpropagation step for Softmax layers with CCE loss.
      * @return Matrix::Matrix<float> Gradient of the loss with respect to this layer's input (dL/dX_prev),
      *                               to be passed to the previous layer.
      * @throws std::runtime_error if dimension mismatches occur during calculations.
      */
-    Matrix::Matrix<float> BackwardPass(const Matrix::Matrix<float>& dLdOutput, const Matrix::Matrix<float>& input_to_this_layer);
+    Matrix::Matrix<float> BackwardPass(const Matrix::Matrix<float>& dLdOutput, const Matrix::Matrix<float>& input_to_this_layer, bool is_last_layer = false);
 
     /**
      * @brief Retrieves the stored gradient of the loss with respect to the layer's weights (dL/dW).

--- a/src/utilities/json/json.cpp
+++ b/src/utilities/json/json.cpp
@@ -164,6 +164,14 @@ std::string JsonParser::ParseString(const std::string& json_string, size_t& inde
 							throw JsonParseException("Unexpected end of string");
 						}
 						std::string hex_string = json_string.substr(index, 4);
+
+						// Verify all 4 characters are valid hex digits before attempting to parse
+						for (char c : hex_string) {
+							if (!std::isxdigit(static_cast<unsigned char>(c))) {
+								throw JsonParseException("Invalid Unicode escape sequence");
+							}
+						}
+
 						size_t chars_processed = 0;
 						try
 						{


### PR DESCRIPTION
Addresses outstanding PR review comments on two areas:
- JSON Parsing: `std::stoi(..., 16)` is too lenient and parses strings containing spaces and signs like `\u+123`. Added a strict check to ensure all four characters after a `\u` are valid hex digits before conversion.
- Softmax Backpropagation: Fixed the shortcut optimization. The assumption that `dLdOutput = A - Y` holds true only for the final output layer of a network using categorical cross-entropy loss. To allow Softmax to be used securely in hidden layers, modified `NeuroNetLayer::BackwardPass` to only apply the `dAdZ` optimization (replacing it with a matrix of ones) when it evaluates the last layer.

---
*PR created automatically by Jules for task [11858071531192549425](https://jules.google.com/task/11858071531192549425) started by @JacobBorden*