### PR TITLE
Add Sigmoid, Tanh, and Swish activation functions

### DIFF
--- a/TODO.MD
+++ b/TODO.MD
@@ -1,6 +1,6 @@
 # TODO
 
-- [ ] Add more activation functions (e.g., Sigmoid, Tanh, Swish).
+- [x] Add more activation functions (e.g., Sigmoid, Tanh, Swish).
 - [ ] Implement Backpropagation algorithm as an alternative to Genetic Algorithm for training.
 - [ ] Add support for Convolutional Neural Networks (CNNs).
 - [ ] Add support for Recurrent Neural Networks (RNNs) / LSTMs.

--- a/src/math/matrix.h
+++ b/src/math/matrix.h
@@ -1053,7 +1053,9 @@ namespace Matrix
         // `i` is the loop control variable for the parallel for.
         // `k`, `j`, and `sum` are declared inside the scope of the `i` loop,
         // making them private to each iteration of the outer loop, and thus to each thread handling an `i`.
-		//#pragma omp parallel for
+#ifdef _OPENMP
+		#pragma omp parallel for
+#endif
 		for (size_t i = 0; i < m_Rows; i++) {
 			for (size_t k = 0; k < b.m_Cols; k++) { // Iterate over columns of b (which is cols of c)
                 T sum = T(0); // Initialize sum for c[i][k]

--- a/src/math/matrix.h
+++ b/src/math/matrix.h
@@ -1053,7 +1053,7 @@ namespace Matrix
         // `i` is the loop control variable for the parallel for.
         // `k`, `j`, and `sum` are declared inside the scope of the `i` loop,
         // making them private to each iteration of the outer loop, and thus to each thread handling an `i`.
-		#pragma omp parallel for
+		//#pragma omp parallel for
 		for (size_t i = 0; i < m_Rows; i++) {
 			for (size_t k = 0; k < b.m_Cols; k++) { // Iterate over columns of b (which is cols of c)
                 T sum = T(0); // Initialize sum for c[i][k]

--- a/src/neural_network/neuronet.cpp
+++ b/src/neural_network/neuronet.cpp
@@ -309,8 +309,8 @@ NeuroNet::ActivationFunctionType NeuroNet::NeuroNetLayer::activation_type_from_s
 
 Matrix::Matrix<float> NeuroNet::NeuroNetLayer::ApplyReLU(const Matrix::Matrix<float>& input) {
     Matrix::Matrix<float> output = input; // Make a copy
-    for (int i = 0; i < output.rows(); ++i) {
-        for (int j = 0; j < output.cols(); ++j) {
+    for (size_t i = 0; i < output.rows(); ++i) {
+        for (size_t j = 0; j < output.cols(); ++j) {
             output[i][j] = std::max(0.0f, output[i][j]);
         }
     }
@@ -320,8 +320,8 @@ Matrix::Matrix<float> NeuroNet::NeuroNetLayer::ApplyReLU(const Matrix::Matrix<fl
 Matrix::Matrix<float> NeuroNet::NeuroNetLayer::ApplyLeakyReLU(const Matrix::Matrix<float>& input) {
     Matrix::Matrix<float> output = input; // Make a copy
     const float alpha = 0.01f;
-    for (int i = 0; i < output.rows(); ++i) {
-        for (int j = 0; j < output.cols(); ++j) {
+    for (size_t i = 0; i < output.rows(); ++i) {
+        for (size_t j = 0; j < output.cols(); ++j) {
             if (output[i][j] < 0) {
                 output[i][j] = alpha * output[i][j];
             }
@@ -333,8 +333,8 @@ Matrix::Matrix<float> NeuroNet::NeuroNetLayer::ApplyLeakyReLU(const Matrix::Matr
 Matrix::Matrix<float> NeuroNet::NeuroNetLayer::ApplyELU(const Matrix::Matrix<float>& input) {
     Matrix::Matrix<float> output = input; // Make a copy
     const float alpha = 1.0f;
-    for (int i = 0; i < output.rows(); ++i) {
-        for (int j = 0; j < output.cols(); ++j) {
+    for (size_t i = 0; i < output.rows(); ++i) {
+        for (size_t j = 0; j < output.cols(); ++j) {
             if (output[i][j] < 0) {
                 output[i][j] = alpha * (std::exp(output[i][j]) - 1.0f);
             }
@@ -345,8 +345,8 @@ Matrix::Matrix<float> NeuroNet::NeuroNetLayer::ApplyELU(const Matrix::Matrix<flo
 
 Matrix::Matrix<float> NeuroNet::NeuroNetLayer::DerivativeReLU(const Matrix::Matrix<float>& activated_output) const {
     Matrix::Matrix<float> derivative = activated_output; // Copy dimensions and initial values
-    for (int i = 0; i < derivative.rows(); ++i) {
-        for (int j = 0; j < derivative.cols(); ++j) {
+    for (size_t i = 0; i < derivative.rows(); ++i) {
+        for (size_t j = 0; j < derivative.cols(); ++j) {
             derivative[i][j] = (activated_output[i][j] > 0.0f) ? 1.0f : 0.0f;
         }
     }
@@ -356,8 +356,8 @@ Matrix::Matrix<float> NeuroNet::NeuroNetLayer::DerivativeReLU(const Matrix::Matr
 Matrix::Matrix<float> NeuroNet::NeuroNetLayer::DerivativeLeakyReLU(const Matrix::Matrix<float>& activated_output) const {
     Matrix::Matrix<float> derivative = activated_output; // Copy dimensions and initial values
     const float alpha = 0.01f; // Ensure this matches the alpha in ApplyLeakyReLU
-    for (int i = 0; i < derivative.rows(); ++i) {
-        for (int j = 0; j < derivative.cols(); ++j) {
+    for (size_t i = 0; i < derivative.rows(); ++i) {
+        for (size_t j = 0; j < derivative.cols(); ++j) {
             derivative[i][j] = (activated_output[i][j] > 0.0f) ? 1.0f : alpha;
         }
     }
@@ -367,8 +367,8 @@ Matrix::Matrix<float> NeuroNet::NeuroNetLayer::DerivativeLeakyReLU(const Matrix:
 Matrix::Matrix<float> NeuroNet::NeuroNetLayer::DerivativeELU(const Matrix::Matrix<float>& activated_output) const {
     Matrix::Matrix<float> derivative = activated_output; // Copy dimensions and initial values
     const float alpha = 1.0f; // Ensure this matches the alpha in ApplyELU
-    for (int i = 0; i < derivative.rows(); ++i) {
-        for (int j = 0; j < derivative.cols(); ++j) {
+    for (size_t i = 0; i < derivative.rows(); ++i) {
+        for (size_t j = 0; j < derivative.cols(); ++j) {
             if (activated_output[i][j] > 0.0f) {
                 derivative[i][j] = 1.0f;
             } else {
@@ -384,8 +384,8 @@ Matrix::Matrix<float> NeuroNet::NeuroNetLayer::DerivativeELU(const Matrix::Matri
 // This is the diagonal of the Jacobian dS/dZ, commonly used with Cross-Entropy loss.
 Matrix::Matrix<float> NeuroNet::NeuroNetLayer::DerivativeSoftmax(const Matrix::Matrix<float>& activated_output) const {
     Matrix::Matrix<float> derivative = activated_output; // Copy dimensions and initial values
-    for (int i = 0; i < derivative.rows(); ++i) {
-        for (int j = 0; j < derivative.cols(); ++j) {
+    for (size_t i = 0; i < derivative.rows(); ++i) {
+        for (size_t j = 0; j < derivative.cols(); ++j) {
             float s_ij = activated_output[i][j];
             derivative[i][j] = s_ij * (1.0f - s_ij);
         }
@@ -462,12 +462,12 @@ Matrix::Matrix<float> NeuroNet::NeuroNetLayer::BackwardPass(const Matrix::Matrix
     if (this->vActivationFunction == ActivationFunctionType::Softmax && !is_last_layer) {
         // Compute dLdZ directly using the Softmax Jacobian:
         // dL/dZ_i = S_i * (dL/dA_i - sum_j (dL/dA_j * S_j))
-        for (int i = 0; i < dLdZ.rows(); ++i) {
+        for (size_t i = 0; i < dLdZ.rows(); ++i) {
             float sum_da_s = 0.0f;
-            for (int j = 0; j < dLdZ.cols(); ++j) {
+            for (size_t j = 0; j < dLdZ.cols(); ++j) {
                 sum_da_s += dLdOutput[i][j] * this->OutputMatrix[i][j];
             }
-            for (int j = 0; j < dLdZ.cols(); ++j) {
+            for (size_t j = 0; j < dLdZ.cols(); ++j) {
                 dLdZ[i][j] = this->OutputMatrix[i][j] * (dLdOutput[i][j] - sum_da_s);
             }
         }
@@ -479,8 +479,8 @@ Matrix::Matrix<float> NeuroNet::NeuroNetLayer::BackwardPass(const Matrix::Matrix
                                      "dLdOutput: (" + std::to_string(dLdOutput.rows()) + "," + std::to_string(dLdOutput.cols()) + ") "
                                      "dAdZ: (" + std::to_string(dAdZ.rows()) + "," + std::to_string(dAdZ.cols()) + ")");
         }
-        for (int i = 0; i < dLdZ.rows(); ++i) {
-            for (int j = 0; j < dLdZ.cols(); ++j) {
+        for (size_t i = 0; i < dLdZ.rows(); ++i) {
+            for (size_t j = 0; j < dLdZ.cols(); ++j) {
                 dLdZ[i][j] = dLdOutput[i][j] * dAdZ[i][j];
             }
         }
@@ -522,8 +522,8 @@ int NeuroNet::NeuroNetLayer::get_input_size() const {
 
 Matrix::Matrix<float> NeuroNet::NeuroNetLayer::ApplySigmoid(const Matrix::Matrix<float>& input) {
     Matrix::Matrix<float> output = input;
-    for (int i = 0; i < output.rows(); ++i) {
-        for (int j = 0; j < output.cols(); ++j) {
+    for (size_t i = 0; i < output.rows(); ++i) {
+        for (size_t j = 0; j < output.cols(); ++j) {
             output[i][j] = 1.0f / (1.0f + std::exp(-output[i][j]));
         }
     }
@@ -532,8 +532,8 @@ Matrix::Matrix<float> NeuroNet::NeuroNetLayer::ApplySigmoid(const Matrix::Matrix
 
 Matrix::Matrix<float> NeuroNet::NeuroNetLayer::ApplyTanh(const Matrix::Matrix<float>& input) {
     Matrix::Matrix<float> output = input;
-    for (int i = 0; i < output.rows(); ++i) {
-        for (int j = 0; j < output.cols(); ++j) {
+    for (size_t i = 0; i < output.rows(); ++i) {
+        for (size_t j = 0; j < output.cols(); ++j) {
             output[i][j] = std::tanh(output[i][j]);
         }
     }
@@ -542,8 +542,8 @@ Matrix::Matrix<float> NeuroNet::NeuroNetLayer::ApplyTanh(const Matrix::Matrix<fl
 
 Matrix::Matrix<float> NeuroNet::NeuroNetLayer::ApplySwish(const Matrix::Matrix<float>& input) {
     Matrix::Matrix<float> output = input;
-    for (int i = 0; i < output.rows(); ++i) {
-        for (int j = 0; j < output.cols(); ++j) {
+    for (size_t i = 0; i < output.rows(); ++i) {
+        for (size_t j = 0; j < output.cols(); ++j) {
             output[i][j] = output[i][j] * (1.0f / (1.0f + std::exp(-output[i][j])));
         }
     }
@@ -552,8 +552,8 @@ Matrix::Matrix<float> NeuroNet::NeuroNetLayer::ApplySwish(const Matrix::Matrix<f
 
 Matrix::Matrix<float> NeuroNet::NeuroNetLayer::DerivativeSigmoid(const Matrix::Matrix<float>& activated_output) const {
     Matrix::Matrix<float> derivative = activated_output;
-    for (int i = 0; i < derivative.rows(); ++i) {
-        for (int j = 0; j < derivative.cols(); ++j) {
+    for (size_t i = 0; i < derivative.rows(); ++i) {
+        for (size_t j = 0; j < derivative.cols(); ++j) {
             float sigmoid_val = activated_output[i][j];
             derivative[i][j] = sigmoid_val * (1.0f - sigmoid_val);
         }
@@ -563,8 +563,8 @@ Matrix::Matrix<float> NeuroNet::NeuroNetLayer::DerivativeSigmoid(const Matrix::M
 
 Matrix::Matrix<float> NeuroNet::NeuroNetLayer::DerivativeTanh(const Matrix::Matrix<float>& activated_output) const {
     Matrix::Matrix<float> derivative = activated_output;
-    for (int i = 0; i < derivative.rows(); ++i) {
-        for (int j = 0; j < derivative.cols(); ++j) {
+    for (size_t i = 0; i < derivative.rows(); ++i) {
+        for (size_t j = 0; j < derivative.cols(); ++j) {
             float tanh_val = activated_output[i][j];
             derivative[i][j] = 1.0f - (tanh_val * tanh_val);
         }
@@ -578,8 +578,8 @@ Matrix::Matrix<float> NeuroNet::NeuroNetLayer::DerivativeSwish(const Matrix::Mat
     // However, we can reconstruct the pre-activation Z matrix here since we have InputMatrix, WeightMatrix, BiasMatrix.
     Matrix::Matrix<float> Z = (this->InputMatrix * this->WeightMatrix) + this->BiasMatrix;
     Matrix::Matrix<float> derivative = activated_output;
-    for (int i = 0; i < derivative.rows(); ++i) {
-        for (int j = 0; j < derivative.cols(); ++j) {
+    for (size_t i = 0; i < derivative.rows(); ++i) {
+        for (size_t j = 0; j < derivative.cols(); ++j) {
             float f_x = activated_output[i][j];
             float sig_x = 1.0f / (1.0f + std::exp(-Z[i][j]));
             derivative[i][j] = f_x + sig_x * (1.0f - f_x);
@@ -599,14 +599,14 @@ Matrix::Matrix<float> NeuroNet::NeuroNetLayer::ApplySoftmax(const Matrix::Matrix
         // this logic would need to be adjusted. For now, it processes a single output vector.
     }
 
-    for (int j = 0; j < output.cols(); ++j) {
+    for (size_t j = 0; j < output.cols(); ++j) {
         output[0][j] = std::exp(output[0][j]);
         sum_exp += output[0][j];
     }
 
     // Normalize
     if (sum_exp != 0.0f) { // Avoid division by zero
-        for (int j = 0; j < output.cols(); ++j) {
+        for (size_t j = 0; j < output.cols(); ++j) {
             output[0][j] /= sum_exp;
         }
     }
@@ -1081,8 +1081,8 @@ bool NeuroNet::NeuroNetLayer::SetWeights(LayerWeights pWeights) {
 	// Or, more directly, the Matrix class might handle this if it can be constructed from a flat vector.
 	// Here, we map it assuming WeightMatrix is InputSize x vLayerSize.
 	int k = 0; // Index for the flat WeightsVector.
-	for (int i = 0; i < this->WeightMatrix.rows(); i++) { // Iterating through rows (inputs)
-		for (int j = 0; j < this->WeightMatrix.cols(); j++) { // Iterating through columns (neurons)
+	for (size_t i = 0; i < this->WeightMatrix.rows(); i++) { // Iterating through rows (inputs)
+		for (size_t j = 0; j < this->WeightMatrix.cols(); j++) { // Iterating through columns (neurons)
 			if (k < this->Weights.WeightCount) {
 				this->WeightMatrix[i][j] = this->Weights.WeightsVector[k];
 				k++;
@@ -1397,8 +1397,8 @@ bool NeuroNet::NeuroNetLayer::SetBiases(LayerBiases pBiases) {
 	// Populate the internal BiasMatrix from the BiasVector.
 	// BiasMatrix is 1 x vLayerSize.
 	int k = 0; // Index for the flat BiasVector.
-	for (int i = 0; i < this->BiasMatrix.rows(); i++) { // Should only be 1 row.
-		for (int j = 0; j < this->BiasMatrix.cols(); j++) { // Iterating through columns (neurons)
+	for (size_t i = 0; i < this->BiasMatrix.rows(); i++) { // Should only be 1 row.
+		for (size_t j = 0; j < this->BiasMatrix.cols(); j++) { // Iterating through columns (neurons)
 			if (k < this->Biases.BiasCount) {
 				this->BiasMatrix[i][j] = this->Biases.BiasVector[k];
 				k++;
@@ -1540,7 +1540,7 @@ NeuroNet::LayerWeights NeuroNet::NeuroNetLayer::get_weights() const {
     LayerWeights current_weights_struct;
     // Use the WeightCount already stored in this->Weights, which ResizeLayer correctly sets.
     current_weights_struct.WeightCount = this->Weights.WeightCount; 
-    if (this->WeightMatrix.rows() * this->WeightMatrix.cols() != current_weights_struct.WeightCount) {
+    if ((int)(this->WeightMatrix.rows() * this->WeightMatrix.cols()) != current_weights_struct.WeightCount) {
         // Optional: Add error handling or log if counts mismatch,
         // but this->Weights.WeightCount should be authoritative if ResizeLayer is always used.
     }
@@ -1548,8 +1548,8 @@ NeuroNet::LayerWeights NeuroNet::NeuroNetLayer::get_weights() const {
     current_weights_struct.WeightsVector.clear(); // Ensure vector is empty before filling
     current_weights_struct.WeightsVector.reserve(current_weights_struct.WeightCount);
 
-    for (int i = 0; i < this->WeightMatrix.rows(); ++i) {
-        for (int j = 0; j < this->WeightMatrix.cols(); ++j) {
+    for (size_t i = 0; i < this->WeightMatrix.rows(); ++i) {
+        for (size_t j = 0; j < this->WeightMatrix.cols(); ++j) {
             current_weights_struct.WeightsVector.push_back(this->WeightMatrix[i][j]);
         }
     }
@@ -1560,7 +1560,7 @@ NeuroNet::LayerBiases NeuroNet::NeuroNetLayer::get_biases() const {
     LayerBiases current_biases_struct;
     // Use the BiasCount already stored in this->Biases, which ResizeLayer correctly sets.
     current_biases_struct.BiasCount = this->Biases.BiasCount;
-    if (this->BiasMatrix.cols() != current_biases_struct.BiasCount && this->BiasMatrix.rows() == 1) {
+    if ((int)this->BiasMatrix.cols() != current_biases_struct.BiasCount && this->BiasMatrix.rows() == 1) {
          // Optional: Add error handling or log if counts mismatch
     }
 
@@ -1568,7 +1568,7 @@ NeuroNet::LayerBiases NeuroNet::NeuroNetLayer::get_biases() const {
     current_biases_struct.BiasVector.reserve(current_biases_struct.BiasCount);
 
     // BiasMatrix is 1xN (1 row, N columns where N is number of neurons/biases)
-    for (int j = 0; j < this->BiasMatrix.cols(); ++j) {
+    for (size_t j = 0; j < this->BiasMatrix.cols(); ++j) {
         current_biases_struct.BiasVector.push_back(this->BiasMatrix[0][j]);
     }
     return current_biases_struct;

--- a/src/neural_network/neuronet.cpp
+++ b/src/neural_network/neuronet.cpp
@@ -82,6 +82,9 @@ std::string NeuroNet::NeuroNetLayer::get_activation_function_name() const {
         case ActivationFunctionType::LeakyReLU: return "LeakyReLU";
         case ActivationFunctionType::ELU: return "ELU";
         case ActivationFunctionType::Softmax: return "Softmax";
+        case ActivationFunctionType::Sigmoid: return "Sigmoid";
+        case ActivationFunctionType::Tanh: return "Tanh";
+        case ActivationFunctionType::Swish: return "Swish";
         default: return "Unknown";
     }
 }
@@ -298,6 +301,9 @@ NeuroNet::ActivationFunctionType NeuroNet::NeuroNetLayer::activation_type_from_s
     if (name == "LeakyReLU") return ActivationFunctionType::LeakyReLU;
     if (name == "ELU") return ActivationFunctionType::ELU;
     if (name == "Softmax") return ActivationFunctionType::Softmax;
+    if (name == "Sigmoid") return ActivationFunctionType::Sigmoid;
+    if (name == "Tanh") return ActivationFunctionType::Tanh;
+    if (name == "Swish") return ActivationFunctionType::Swish;
     throw std::invalid_argument("Unknown activation function name: " + name);
 }
 
@@ -416,6 +422,15 @@ Matrix::Matrix<float> NeuroNet::NeuroNetLayer::BackwardPass(const Matrix::Matrix
         case ActivationFunctionType::ELU:
             dAdZ = DerivativeELU(this->OutputMatrix);
             break;
+        case ActivationFunctionType::Sigmoid:
+            dAdZ = DerivativeSigmoid(this->OutputMatrix);
+            break;
+        case ActivationFunctionType::Tanh:
+            dAdZ = DerivativeTanh(this->OutputMatrix);
+            break;
+        case ActivationFunctionType::Swish:
+            dAdZ = DerivativeSwish(this->OutputMatrix);
+            break;
         case ActivationFunctionType::Softmax:
             if (is_last_layer) {
                 // For Softmax with Cross-Entropy loss on the last layer, dL/dZ = A - Y (output - target).
@@ -505,6 +520,74 @@ int NeuroNet::NeuroNetLayer::get_input_size() const {
     return this->InputSize;
 }
 
+Matrix::Matrix<float> NeuroNet::NeuroNetLayer::ApplySigmoid(const Matrix::Matrix<float>& input) {
+    Matrix::Matrix<float> output = input;
+    for (int i = 0; i < output.rows(); ++i) {
+        for (int j = 0; j < output.cols(); ++j) {
+            output[i][j] = 1.0f / (1.0f + std::exp(-output[i][j]));
+        }
+    }
+    return output;
+}
+
+Matrix::Matrix<float> NeuroNet::NeuroNetLayer::ApplyTanh(const Matrix::Matrix<float>& input) {
+    Matrix::Matrix<float> output = input;
+    for (int i = 0; i < output.rows(); ++i) {
+        for (int j = 0; j < output.cols(); ++j) {
+            output[i][j] = std::tanh(output[i][j]);
+        }
+    }
+    return output;
+}
+
+Matrix::Matrix<float> NeuroNet::NeuroNetLayer::ApplySwish(const Matrix::Matrix<float>& input) {
+    Matrix::Matrix<float> output = input;
+    for (int i = 0; i < output.rows(); ++i) {
+        for (int j = 0; j < output.cols(); ++j) {
+            output[i][j] = output[i][j] * (1.0f / (1.0f + std::exp(-output[i][j])));
+        }
+    }
+    return output;
+}
+
+Matrix::Matrix<float> NeuroNet::NeuroNetLayer::DerivativeSigmoid(const Matrix::Matrix<float>& activated_output) const {
+    Matrix::Matrix<float> derivative = activated_output;
+    for (int i = 0; i < derivative.rows(); ++i) {
+        for (int j = 0; j < derivative.cols(); ++j) {
+            float sigmoid_val = activated_output[i][j];
+            derivative[i][j] = sigmoid_val * (1.0f - sigmoid_val);
+        }
+    }
+    return derivative;
+}
+
+Matrix::Matrix<float> NeuroNet::NeuroNetLayer::DerivativeTanh(const Matrix::Matrix<float>& activated_output) const {
+    Matrix::Matrix<float> derivative = activated_output;
+    for (int i = 0; i < derivative.rows(); ++i) {
+        for (int j = 0; j < derivative.cols(); ++j) {
+            float tanh_val = activated_output[i][j];
+            derivative[i][j] = 1.0f - (tanh_val * tanh_val);
+        }
+    }
+    return derivative;
+}
+
+Matrix::Matrix<float> NeuroNet::NeuroNetLayer::DerivativeSwish(const Matrix::Matrix<float>& activated_output) const {
+    // For Swish, f'(x) = f(x) + sigmoid(x) * (1 - f(x))
+    // To compute sigmoid(x), we'd ideally need pre-activation x.
+    // However, we can reconstruct the pre-activation Z matrix here since we have InputMatrix, WeightMatrix, BiasMatrix.
+    Matrix::Matrix<float> Z = (this->InputMatrix * this->WeightMatrix) + this->BiasMatrix;
+    Matrix::Matrix<float> derivative = activated_output;
+    for (int i = 0; i < derivative.rows(); ++i) {
+        for (int j = 0; j < derivative.cols(); ++j) {
+            float f_x = activated_output[i][j];
+            float sig_x = 1.0f / (1.0f + std::exp(-Z[i][j]));
+            derivative[i][j] = f_x + sig_x * (1.0f - f_x);
+        }
+    }
+    return derivative;
+}
+
 Matrix::Matrix<float> NeuroNet::NeuroNetLayer::ApplySoftmax(const Matrix::Matrix<float>& input) {
     Matrix::Matrix<float> output = input; // Make a copy
     float sum_exp = 0.0f;
@@ -568,6 +651,15 @@ Matrix::Matrix<float> NeuroNet::NeuroNetLayer::CalculateOutput() {
             break;
         case ActivationFunctionType::Softmax:
             this->OutputMatrix = ApplySoftmax(this->OutputMatrix);
+            break;
+        case ActivationFunctionType::Sigmoid:
+            this->OutputMatrix = ApplySigmoid(this->OutputMatrix);
+            break;
+        case ActivationFunctionType::Tanh:
+            this->OutputMatrix = ApplyTanh(this->OutputMatrix);
+            break;
+        case ActivationFunctionType::Swish:
+            this->OutputMatrix = ApplySwish(this->OutputMatrix);
             break;
         case ActivationFunctionType::None:
             // No activation function applied, do nothing.

--- a/src/neural_network/neuronet.h
+++ b/src/neural_network/neuronet.h
@@ -35,7 +35,10 @@ namespace NeuroNet
 		ReLU,      ///< Rectified Linear Unit. Output is max(0, x).
 		LeakyReLU, ///< Leaky Rectified Linear Unit. Output is x if x > 0, otherwise alpha*x.
 		ELU,       ///< Exponential Linear Unit. Output is x if x > 0, otherwise alpha*(exp(x)-1).
-		Softmax    ///< Softmax function. Normalizes outputs to a probability distribution.
+		Softmax,   ///< Softmax function. Normalizes outputs to a probability distribution.
+		Sigmoid,   ///< Sigmoid function. Output is 1 / (1 + exp(-x)).
+		Tanh,      ///< Hyperbolic Tangent. Output is tanh(x).
+		Swish      ///< Swish function. Output is x * sigmoid(x).
 	};
 
 	/**
@@ -220,6 +223,27 @@ namespace NeuroNet
     Matrix::Matrix<float> DerivativeSoftmax(const Matrix::Matrix<float>& activated_output) const;
 
     /**
+     * @brief Computes the element-wise derivative of the Sigmoid activation function.
+     * @param activated_output The matrix of outputs after Sigmoid activation was applied.
+     * @return Matrix::Matrix<float> A matrix containing the derivatives.
+     */
+    Matrix::Matrix<float> DerivativeSigmoid(const Matrix::Matrix<float>& activated_output) const;
+
+    /**
+     * @brief Computes the element-wise derivative of the Tanh activation function.
+     * @param activated_output The matrix of outputs after Tanh activation was applied.
+     * @return Matrix::Matrix<float> A matrix containing the derivatives.
+     */
+    Matrix::Matrix<float> DerivativeTanh(const Matrix::Matrix<float>& activated_output) const;
+
+    /**
+     * @brief Computes the element-wise derivative of the Swish activation function.
+     * @param activated_output The matrix of outputs after Swish activation was applied.
+     * @return Matrix::Matrix<float> A matrix containing the derivatives.
+     */
+    Matrix::Matrix<float> DerivativeSwish(const Matrix::Matrix<float>& activated_output) const;
+
+    /**
      * @brief Performs the backward pass for this layer.
      *
      * Calculates the gradients of the loss with respect to the layer's weights (dLdW),
@@ -315,6 +339,24 @@ namespace NeuroNet
      * @return Matrix::Matrix<float> The matrix after applying Softmax.
      */
     Matrix::Matrix<float> ApplySoftmax(const Matrix::Matrix<float>& input);
+    /**
+     * @brief Applies the Sigmoid activation function element-wise to the input matrix.
+     * @param input The matrix resulting from the linear transformation (Wx + b).
+     * @return Matrix::Matrix<float> The matrix after applying Sigmoid.
+     */
+    Matrix::Matrix<float> ApplySigmoid(const Matrix::Matrix<float>& input);
+    /**
+     * @brief Applies the Tanh activation function element-wise to the input matrix.
+     * @param input The matrix resulting from the linear transformation (Wx + b).
+     * @return Matrix::Matrix<float> The matrix after applying Tanh.
+     */
+    Matrix::Matrix<float> ApplyTanh(const Matrix::Matrix<float>& input);
+    /**
+     * @brief Applies the Swish activation function element-wise to the input matrix.
+     * @param input The matrix resulting from the linear transformation (Wx + b).
+     * @return Matrix::Matrix<float> The matrix after applying Swish.
+     */
+    Matrix::Matrix<float> ApplySwish(const Matrix::Matrix<float>& input);
 	};
 
 	/**

--- a/src/utilities/json/json.cpp
+++ b/src/utilities/json/json.cpp
@@ -457,7 +457,7 @@ void JsonParser::SkipComment(const std::string& json_string, size_t& index)
     // For now, Parse() calls SkipComment once at the beginning.
     while (index < json_string.length()) {
         // SkipWhitespace(json_string, index); // Moved to be called before each ParseValue attempt by caller or main loop
-        bool comment_found = false;
+        //bool comment_found = false;
         if (index + 1 < json_string.length()) {
             if (json_string[index] == '/' && json_string[index + 1] == '/') {
                 index += 2; // Skip '//'

--- a/tests/test_genetic_algorithm.cpp
+++ b/tests/test_genetic_algorithm.cpp
@@ -234,7 +234,7 @@ TEST_F(GeneticAlgorithmTest, GetBestIndividual) {
     ga.evolve_one_generation(simple_fitness_function, 1); // Using 1 as a dummy generation number for the test
     
     NeuroNet::NeuroNet reported_best = ga.get_best_individual();
-    double reported_best_fitness = simple_fitness_function(reported_best);
+    //double reported_best_fitness = simple_fitness_function(reported_best);
 
     // We expect that after evaluation, the reported_best_fitness is indeed the max.
     // This doesn't strictly test if `clearly_best_net` was found, but that `get_best_individual` works.

--- a/tests/test_neuronet.cpp
+++ b/tests/test_neuronet.cpp
@@ -761,6 +761,93 @@ TEST_F(NeuroNetTest, ActivationNone) {
     EXPECT_FLOAT_EQ(output[0][2], 0.5f);
 }
 
+TEST_F(NeuroNetTest, ActivationSigmoid) {
+    int num_inputs = 1;
+    int num_outputs = 3;
+    layer.ResizeLayer(num_inputs, num_outputs);
+
+    NeuroNet::LayerWeights weights;
+    weights.WeightCount = 3;
+    weights.WeightsVector = {1.0f, -1.0f, 0.0f};
+    layer.SetWeights(weights);
+
+    NeuroNet::LayerBiases biases;
+    biases.BiasCount = 3;
+    biases.BiasVector = {0.0f, 0.0f, 0.0f};
+    layer.SetBiases(biases);
+
+    Matrix::Matrix<float> input(1, 1);
+    input[0][0] = 1.0f;
+    layer.SetInput(input);
+
+    layer.SetActivationFunction(NeuroNet::ActivationFunctionType::Sigmoid);
+    Matrix::Matrix<float> output = layer.CalculateOutput();
+
+    EXPECT_EQ(output.rows(), 1);
+    EXPECT_EQ(output.cols(), num_outputs);
+    EXPECT_FLOAT_EQ(output[0][0], 1.0f / (1.0f + std::exp(-1.0f)));
+    EXPECT_FLOAT_EQ(output[0][1], 1.0f / (1.0f + std::exp(1.0f)));
+    EXPECT_FLOAT_EQ(output[0][2], 0.5f);
+}
+
+TEST_F(NeuroNetTest, ActivationTanh) {
+    int num_inputs = 1;
+    int num_outputs = 3;
+    layer.ResizeLayer(num_inputs, num_outputs);
+
+    NeuroNet::LayerWeights weights;
+    weights.WeightCount = 3;
+    weights.WeightsVector = {1.0f, -1.0f, 0.0f};
+    layer.SetWeights(weights);
+
+    NeuroNet::LayerBiases biases;
+    biases.BiasCount = 3;
+    biases.BiasVector = {0.0f, 0.0f, 0.0f};
+    layer.SetBiases(biases);
+
+    Matrix::Matrix<float> input(1, 1);
+    input[0][0] = 1.0f;
+    layer.SetInput(input);
+
+    layer.SetActivationFunction(NeuroNet::ActivationFunctionType::Tanh);
+    Matrix::Matrix<float> output = layer.CalculateOutput();
+
+    EXPECT_EQ(output.rows(), 1);
+    EXPECT_EQ(output.cols(), num_outputs);
+    EXPECT_FLOAT_EQ(output[0][0], std::tanh(1.0f));
+    EXPECT_FLOAT_EQ(output[0][1], std::tanh(-1.0f));
+    EXPECT_FLOAT_EQ(output[0][2], 0.0f);
+}
+
+TEST_F(NeuroNetTest, ActivationSwish) {
+    int num_inputs = 1;
+    int num_outputs = 3;
+    layer.ResizeLayer(num_inputs, num_outputs);
+
+    NeuroNet::LayerWeights weights;
+    weights.WeightCount = 3;
+    weights.WeightsVector = {1.0f, -1.0f, 0.0f};
+    layer.SetWeights(weights);
+
+    NeuroNet::LayerBiases biases;
+    biases.BiasCount = 3;
+    biases.BiasVector = {0.0f, 0.0f, 0.0f};
+    layer.SetBiases(biases);
+
+    Matrix::Matrix<float> input(1, 1);
+    input[0][0] = 2.0f;
+    layer.SetInput(input);
+
+    layer.SetActivationFunction(NeuroNet::ActivationFunctionType::Swish);
+    Matrix::Matrix<float> output = layer.CalculateOutput();
+
+    EXPECT_EQ(output.rows(), 1);
+    EXPECT_EQ(output.cols(), num_outputs);
+    EXPECT_FLOAT_EQ(output[0][0], 2.0f * (1.0f / (1.0f + std::exp(-2.0f))));
+    EXPECT_FLOAT_EQ(output[0][1], -2.0f * (1.0f / (1.0f + std::exp(2.0f))));
+    EXPECT_FLOAT_EQ(output[0][2], 0.0f);
+}
+
 // --- End of Activation Function Tests ---
 
 TEST_F(NeuroNetTest, Serialization) {

--- a/tests/test_transformer_model.cpp
+++ b/tests/test_transformer_model.cpp
@@ -141,7 +141,7 @@ TEST_F(TransformerModelTest, ForwardPassInputTooLong) {
 
     const int current_seq_len = max_seq_len_test + 1; // Sequence length 6
     Matrix::Matrix<float> long_input_sequence(1, current_seq_len);
-    for (int j = 0; j < long_input_sequence.cols(); ++j) {
+    for (size_t j = 0; j < long_input_sequence.cols(); ++j) {
         long_input_sequence[0][j] = static_cast<float>(j + 1);
     }
     Matrix::Matrix<float> mask(1, current_seq_len);


### PR DESCRIPTION
This pull request adds Sigmoid, Tanh, and Swish activation functions to the NeuroNet library. It includes both the forward pass and the analytical derivatives for the backward pass. Appropriate tests have been added to ensure mathematical correctness.

---
*PR created automatically by Jules for task [3089978813156557868](https://jules.google.com/task/3089978813156557868) started by @JacobBorden*