### PR TITLE
Fix build issues

### DIFF
--- a/src/math/matrix.h
+++ b/src/math/matrix.h
@@ -1053,7 +1053,9 @@ namespace Matrix
         // `i` is the loop control variable for the parallel for.
         // `k`, `j`, and `sum` are declared inside the scope of the `i` loop,
         // making them private to each iteration of the outer loop, and thus to each thread handling an `i`.
-		//#pragma omp parallel for
+#ifdef _OPENMP
+		#pragma omp parallel for
+#endif
 		for (size_t i = 0; i < m_Rows; i++) {
 			for (size_t k = 0; k < b.m_Cols; k++) { // Iterate over columns of b (which is cols of c)
                 T sum = T(0); // Initialize sum for c[i][k]

--- a/src/math/matrix.h
+++ b/src/math/matrix.h
@@ -1053,7 +1053,7 @@ namespace Matrix
         // `i` is the loop control variable for the parallel for.
         // `k`, `j`, and `sum` are declared inside the scope of the `i` loop,
         // making them private to each iteration of the outer loop, and thus to each thread handling an `i`.
-		#pragma omp parallel for
+		//#pragma omp parallel for
 		for (size_t i = 0; i < m_Rows; i++) {
 			for (size_t k = 0; k < b.m_Cols; k++) { // Iterate over columns of b (which is cols of c)
                 T sum = T(0); // Initialize sum for c[i][k]

--- a/src/neural_network/neuronet.cpp
+++ b/src/neural_network/neuronet.cpp
@@ -309,8 +309,8 @@ NeuroNet::ActivationFunctionType NeuroNet::NeuroNetLayer::activation_type_from_s
 
 Matrix::Matrix<float> NeuroNet::NeuroNetLayer::ApplyReLU(const Matrix::Matrix<float>& input) {
     Matrix::Matrix<float> output = input; // Make a copy
-    for (int i = 0; i < output.rows(); ++i) {
-        for (int j = 0; j < output.cols(); ++j) {
+    for (size_t i = 0; i < output.rows(); ++i) {
+        for (size_t j = 0; j < output.cols(); ++j) {
             output[i][j] = std::max(0.0f, output[i][j]);
         }
     }
@@ -320,8 +320,8 @@ Matrix::Matrix<float> NeuroNet::NeuroNetLayer::ApplyReLU(const Matrix::Matrix<fl
 Matrix::Matrix<float> NeuroNet::NeuroNetLayer::ApplyLeakyReLU(const Matrix::Matrix<float>& input) {
     Matrix::Matrix<float> output = input; // Make a copy
     const float alpha = 0.01f;
-    for (int i = 0; i < output.rows(); ++i) {
-        for (int j = 0; j < output.cols(); ++j) {
+    for (size_t i = 0; i < output.rows(); ++i) {
+        for (size_t j = 0; j < output.cols(); ++j) {
             if (output[i][j] < 0) {
                 output[i][j] = alpha * output[i][j];
             }
@@ -333,8 +333,8 @@ Matrix::Matrix<float> NeuroNet::NeuroNetLayer::ApplyLeakyReLU(const Matrix::Matr
 Matrix::Matrix<float> NeuroNet::NeuroNetLayer::ApplyELU(const Matrix::Matrix<float>& input) {
     Matrix::Matrix<float> output = input; // Make a copy
     const float alpha = 1.0f;
-    for (int i = 0; i < output.rows(); ++i) {
-        for (int j = 0; j < output.cols(); ++j) {
+    for (size_t i = 0; i < output.rows(); ++i) {
+        for (size_t j = 0; j < output.cols(); ++j) {
             if (output[i][j] < 0) {
                 output[i][j] = alpha * (std::exp(output[i][j]) - 1.0f);
             }
@@ -345,8 +345,8 @@ Matrix::Matrix<float> NeuroNet::NeuroNetLayer::ApplyELU(const Matrix::Matrix<flo
 
 Matrix::Matrix<float> NeuroNet::NeuroNetLayer::DerivativeReLU(const Matrix::Matrix<float>& activated_output) const {
     Matrix::Matrix<float> derivative = activated_output; // Copy dimensions and initial values
-    for (int i = 0; i < derivative.rows(); ++i) {
-        for (int j = 0; j < derivative.cols(); ++j) {
+    for (size_t i = 0; i < derivative.rows(); ++i) {
+        for (size_t j = 0; j < derivative.cols(); ++j) {
             derivative[i][j] = (activated_output[i][j] > 0.0f) ? 1.0f : 0.0f;
         }
     }
@@ -356,8 +356,8 @@ Matrix::Matrix<float> NeuroNet::NeuroNetLayer::DerivativeReLU(const Matrix::Matr
 Matrix::Matrix<float> NeuroNet::NeuroNetLayer::DerivativeLeakyReLU(const Matrix::Matrix<float>& activated_output) const {
     Matrix::Matrix<float> derivative = activated_output; // Copy dimensions and initial values
     const float alpha = 0.01f; // Ensure this matches the alpha in ApplyLeakyReLU
-    for (int i = 0; i < derivative.rows(); ++i) {
-        for (int j = 0; j < derivative.cols(); ++j) {
+    for (size_t i = 0; i < derivative.rows(); ++i) {
+        for (size_t j = 0; j < derivative.cols(); ++j) {
             derivative[i][j] = (activated_output[i][j] > 0.0f) ? 1.0f : alpha;
         }
     }
@@ -367,8 +367,8 @@ Matrix::Matrix<float> NeuroNet::NeuroNetLayer::DerivativeLeakyReLU(const Matrix:
 Matrix::Matrix<float> NeuroNet::NeuroNetLayer::DerivativeELU(const Matrix::Matrix<float>& activated_output) const {
     Matrix::Matrix<float> derivative = activated_output; // Copy dimensions and initial values
     const float alpha = 1.0f; // Ensure this matches the alpha in ApplyELU
-    for (int i = 0; i < derivative.rows(); ++i) {
-        for (int j = 0; j < derivative.cols(); ++j) {
+    for (size_t i = 0; i < derivative.rows(); ++i) {
+        for (size_t j = 0; j < derivative.cols(); ++j) {
             if (activated_output[i][j] > 0.0f) {
                 derivative[i][j] = 1.0f;
             } else {
@@ -384,8 +384,8 @@ Matrix::Matrix<float> NeuroNet::NeuroNetLayer::DerivativeELU(const Matrix::Matri
 // This is the diagonal of the Jacobian dS/dZ, commonly used with Cross-Entropy loss.
 Matrix::Matrix<float> NeuroNet::NeuroNetLayer::DerivativeSoftmax(const Matrix::Matrix<float>& activated_output) const {
     Matrix::Matrix<float> derivative = activated_output; // Copy dimensions and initial values
-    for (int i = 0; i < derivative.rows(); ++i) {
-        for (int j = 0; j < derivative.cols(); ++j) {
+    for (size_t i = 0; i < derivative.rows(); ++i) {
+        for (size_t j = 0; j < derivative.cols(); ++j) {
             float s_ij = activated_output[i][j];
             derivative[i][j] = s_ij * (1.0f - s_ij);
         }
@@ -462,12 +462,12 @@ Matrix::Matrix<float> NeuroNet::NeuroNetLayer::BackwardPass(const Matrix::Matrix
     if (this->vActivationFunction == ActivationFunctionType::Softmax && !is_last_layer) {
         // Compute dLdZ directly using the Softmax Jacobian:
         // dL/dZ_i = S_i * (dL/dA_i - sum_j (dL/dA_j * S_j))
-        for (int i = 0; i < dLdZ.rows(); ++i) {
+        for (size_t i = 0; i < dLdZ.rows(); ++i) {
             float sum_da_s = 0.0f;
-            for (int j = 0; j < dLdZ.cols(); ++j) {
+            for (size_t j = 0; j < dLdZ.cols(); ++j) {
                 sum_da_s += dLdOutput[i][j] * this->OutputMatrix[i][j];
             }
-            for (int j = 0; j < dLdZ.cols(); ++j) {
+            for (size_t j = 0; j < dLdZ.cols(); ++j) {
                 dLdZ[i][j] = this->OutputMatrix[i][j] * (dLdOutput[i][j] - sum_da_s);
             }
         }
@@ -479,8 +479,8 @@ Matrix::Matrix<float> NeuroNet::NeuroNetLayer::BackwardPass(const Matrix::Matrix
                                      "dLdOutput: (" + std::to_string(dLdOutput.rows()) + "," + std::to_string(dLdOutput.cols()) + ") "
                                      "dAdZ: (" + std::to_string(dAdZ.rows()) + "," + std::to_string(dAdZ.cols()) + ")");
         }
-        for (int i = 0; i < dLdZ.rows(); ++i) {
-            for (int j = 0; j < dLdZ.cols(); ++j) {
+        for (size_t i = 0; i < dLdZ.rows(); ++i) {
+            for (size_t j = 0; j < dLdZ.cols(); ++j) {
                 dLdZ[i][j] = dLdOutput[i][j] * dAdZ[i][j];
             }
         }
@@ -522,8 +522,8 @@ int NeuroNet::NeuroNetLayer::get_input_size() const {
 
 Matrix::Matrix<float> NeuroNet::NeuroNetLayer::ApplySigmoid(const Matrix::Matrix<float>& input) {
     Matrix::Matrix<float> output = input;
-    for (int i = 0; i < output.rows(); ++i) {
-        for (int j = 0; j < output.cols(); ++j) {
+    for (size_t i = 0; i < output.rows(); ++i) {
+        for (size_t j = 0; j < output.cols(); ++j) {
             output[i][j] = 1.0f / (1.0f + std::exp(-output[i][j]));
         }
     }
@@ -532,8 +532,8 @@ Matrix::Matrix<float> NeuroNet::NeuroNetLayer::ApplySigmoid(const Matrix::Matrix
 
 Matrix::Matrix<float> NeuroNet::NeuroNetLayer::ApplyTanh(const Matrix::Matrix<float>& input) {
     Matrix::Matrix<float> output = input;
-    for (int i = 0; i < output.rows(); ++i) {
-        for (int j = 0; j < output.cols(); ++j) {
+    for (size_t i = 0; i < output.rows(); ++i) {
+        for (size_t j = 0; j < output.cols(); ++j) {
             output[i][j] = std::tanh(output[i][j]);
         }
     }
@@ -542,8 +542,8 @@ Matrix::Matrix<float> NeuroNet::NeuroNetLayer::ApplyTanh(const Matrix::Matrix<fl
 
 Matrix::Matrix<float> NeuroNet::NeuroNetLayer::ApplySwish(const Matrix::Matrix<float>& input) {
     Matrix::Matrix<float> output = input;
-    for (int i = 0; i < output.rows(); ++i) {
-        for (int j = 0; j < output.cols(); ++j) {
+    for (size_t i = 0; i < output.rows(); ++i) {
+        for (size_t j = 0; j < output.cols(); ++j) {
             output[i][j] = output[i][j] * (1.0f / (1.0f + std::exp(-output[i][j])));
         }
     }
@@ -552,8 +552,8 @@ Matrix::Matrix<float> NeuroNet::NeuroNetLayer::ApplySwish(const Matrix::Matrix<f
 
 Matrix::Matrix<float> NeuroNet::NeuroNetLayer::DerivativeSigmoid(const Matrix::Matrix<float>& activated_output) const {
     Matrix::Matrix<float> derivative = activated_output;
-    for (int i = 0; i < derivative.rows(); ++i) {
-        for (int j = 0; j < derivative.cols(); ++j) {
+    for (size_t i = 0; i < derivative.rows(); ++i) {
+        for (size_t j = 0; j < derivative.cols(); ++j) {
             float sigmoid_val = activated_output[i][j];
             derivative[i][j] = sigmoid_val * (1.0f - sigmoid_val);
         }
@@ -563,8 +563,8 @@ Matrix::Matrix<float> NeuroNet::NeuroNetLayer::DerivativeSigmoid(const Matrix::M
 
 Matrix::Matrix<float> NeuroNet::NeuroNetLayer::DerivativeTanh(const Matrix::Matrix<float>& activated_output) const {
     Matrix::Matrix<float> derivative = activated_output;
-    for (int i = 0; i < derivative.rows(); ++i) {
-        for (int j = 0; j < derivative.cols(); ++j) {
+    for (size_t i = 0; i < derivative.rows(); ++i) {
+        for (size_t j = 0; j < derivative.cols(); ++j) {
             float tanh_val = activated_output[i][j];
             derivative[i][j] = 1.0f - (tanh_val * tanh_val);
         }
@@ -578,8 +578,8 @@ Matrix::Matrix<float> NeuroNet::NeuroNetLayer::DerivativeSwish(const Matrix::Mat
     // However, we can reconstruct the pre-activation Z matrix here since we have InputMatrix, WeightMatrix, BiasMatrix.
     Matrix::Matrix<float> Z = (this->InputMatrix * this->WeightMatrix) + this->BiasMatrix;
     Matrix::Matrix<float> derivative = activated_output;
-    for (int i = 0; i < derivative.rows(); ++i) {
-        for (int j = 0; j < derivative.cols(); ++j) {
+    for (size_t i = 0; i < derivative.rows(); ++i) {
+        for (size_t j = 0; j < derivative.cols(); ++j) {
             float f_x = activated_output[i][j];
             float sig_x = 1.0f / (1.0f + std::exp(-Z[i][j]));
             derivative[i][j] = f_x + sig_x * (1.0f - f_x);
@@ -599,14 +599,14 @@ Matrix::Matrix<float> NeuroNet::NeuroNetLayer::ApplySoftmax(const Matrix::Matrix
         // this logic would need to be adjusted. For now, it processes a single output vector.
     }
 
-    for (int j = 0; j < output.cols(); ++j) {
+    for (size_t j = 0; j < output.cols(); ++j) {
         output[0][j] = std::exp(output[0][j]);
         sum_exp += output[0][j];
     }
 
     // Normalize
     if (sum_exp != 0.0f) { // Avoid division by zero
-        for (int j = 0; j < output.cols(); ++j) {
+        for (size_t j = 0; j < output.cols(); ++j) {
             output[0][j] /= sum_exp;
         }
     }
@@ -1081,8 +1081,8 @@ bool NeuroNet::NeuroNetLayer::SetWeights(LayerWeights pWeights) {
 	// Or, more directly, the Matrix class might handle this if it can be constructed from a flat vector.
 	// Here, we map it assuming WeightMatrix is InputSize x vLayerSize.
 	int k = 0; // Index for the flat WeightsVector.
-	for (int i = 0; i < this->WeightMatrix.rows(); i++) { // Iterating through rows (inputs)
-		for (int j = 0; j < this->WeightMatrix.cols(); j++) { // Iterating through columns (neurons)
+	for (size_t i = 0; i < this->WeightMatrix.rows(); i++) { // Iterating through rows (inputs)
+		for (size_t j = 0; j < this->WeightMatrix.cols(); j++) { // Iterating through columns (neurons)
 			if (k < this->Weights.WeightCount) {
 				this->WeightMatrix[i][j] = this->Weights.WeightsVector[k];
 				k++;
@@ -1397,8 +1397,8 @@ bool NeuroNet::NeuroNetLayer::SetBiases(LayerBiases pBiases) {
 	// Populate the internal BiasMatrix from the BiasVector.
 	// BiasMatrix is 1 x vLayerSize.
 	int k = 0; // Index for the flat BiasVector.
-	for (int i = 0; i < this->BiasMatrix.rows(); i++) { // Should only be 1 row.
-		for (int j = 0; j < this->BiasMatrix.cols(); j++) { // Iterating through columns (neurons)
+	for (size_t i = 0; i < this->BiasMatrix.rows(); i++) { // Should only be 1 row.
+		for (size_t j = 0; j < this->BiasMatrix.cols(); j++) { // Iterating through columns (neurons)
 			if (k < this->Biases.BiasCount) {
 				this->BiasMatrix[i][j] = this->Biases.BiasVector[k];
 				k++;
@@ -1540,7 +1540,7 @@ NeuroNet::LayerWeights NeuroNet::NeuroNetLayer::get_weights() const {
     LayerWeights current_weights_struct;
     // Use the WeightCount already stored in this->Weights, which ResizeLayer correctly sets.
     current_weights_struct.WeightCount = this->Weights.WeightCount; 
-    if (this->WeightMatrix.rows() * this->WeightMatrix.cols() != current_weights_struct.WeightCount) {
+    if ((int)(this->WeightMatrix.rows() * this->WeightMatrix.cols()) != current_weights_struct.WeightCount) {
         // Optional: Add error handling or log if counts mismatch,
         // but this->Weights.WeightCount should be authoritative if ResizeLayer is always used.
     }
@@ -1548,8 +1548,8 @@ NeuroNet::LayerWeights NeuroNet::NeuroNetLayer::get_weights() const {
     current_weights_struct.WeightsVector.clear(); // Ensure vector is empty before filling
     current_weights_struct.WeightsVector.reserve(current_weights_struct.WeightCount);
 
-    for (int i = 0; i < this->WeightMatrix.rows(); ++i) {
-        for (int j = 0; j < this->WeightMatrix.cols(); ++j) {
+    for (size_t i = 0; i < this->WeightMatrix.rows(); ++i) {
+        for (size_t j = 0; j < this->WeightMatrix.cols(); ++j) {
             current_weights_struct.WeightsVector.push_back(this->WeightMatrix[i][j]);
         }
     }
@@ -1560,7 +1560,7 @@ NeuroNet::LayerBiases NeuroNet::NeuroNetLayer::get_biases() const {
     LayerBiases current_biases_struct;
     // Use the BiasCount already stored in this->Biases, which ResizeLayer correctly sets.
     current_biases_struct.BiasCount = this->Biases.BiasCount;
-    if (this->BiasMatrix.cols() != current_biases_struct.BiasCount && this->BiasMatrix.rows() == 1) {
+    if ((int)this->BiasMatrix.cols() != current_biases_struct.BiasCount && this->BiasMatrix.rows() == 1) {
          // Optional: Add error handling or log if counts mismatch
     }
 
@@ -1568,7 +1568,7 @@ NeuroNet::LayerBiases NeuroNet::NeuroNetLayer::get_biases() const {
     current_biases_struct.BiasVector.reserve(current_biases_struct.BiasCount);
 
     // BiasMatrix is 1xN (1 row, N columns where N is number of neurons/biases)
-    for (int j = 0; j < this->BiasMatrix.cols(); ++j) {
+    for (size_t j = 0; j < this->BiasMatrix.cols(); ++j) {
         current_biases_struct.BiasVector.push_back(this->BiasMatrix[0][j]);
     }
     return current_biases_struct;

--- a/src/utilities/json/json.cpp
+++ b/src/utilities/json/json.cpp
@@ -457,7 +457,7 @@ void JsonParser::SkipComment(const std::string& json_string, size_t& index)
     // For now, Parse() calls SkipComment once at the beginning.
     while (index < json_string.length()) {
         // SkipWhitespace(json_string, index); // Moved to be called before each ParseValue attempt by caller or main loop
-        bool comment_found = false;
+        //bool comment_found = false;
         if (index + 1 < json_string.length()) {
             if (json_string[index] == '/' && json_string[index + 1] == '/') {
                 index += 2; // Skip '//'

--- a/tests/test_genetic_algorithm.cpp
+++ b/tests/test_genetic_algorithm.cpp
@@ -234,7 +234,7 @@ TEST_F(GeneticAlgorithmTest, GetBestIndividual) {
     ga.evolve_one_generation(simple_fitness_function, 1); // Using 1 as a dummy generation number for the test
     
     NeuroNet::NeuroNet reported_best = ga.get_best_individual();
-    double reported_best_fitness = simple_fitness_function(reported_best);
+    //double reported_best_fitness = simple_fitness_function(reported_best);
 
     // We expect that after evaluation, the reported_best_fitness is indeed the max.
     // This doesn't strictly test if `clearly_best_net` was found, but that `get_best_individual` works.

--- a/tests/test_transformer_model.cpp
+++ b/tests/test_transformer_model.cpp
@@ -141,7 +141,7 @@ TEST_F(TransformerModelTest, ForwardPassInputTooLong) {
 
     const int current_seq_len = max_seq_len_test + 1; // Sequence length 6
     Matrix::Matrix<float> long_input_sequence(1, current_seq_len);
-    for (int j = 0; j < long_input_sequence.cols(); ++j) {
+    for (size_t j = 0; j < long_input_sequence.cols(); ++j) {
         long_input_sequence[0][j] = static_cast<float>(j + 1);
     }
     Matrix::Matrix<float> mask(1, current_seq_len);


### PR DESCRIPTION
Fix compiler warnings by changing int to size_t for matrix loop indices, commenting out unused variables, and commenting out unused OpenMP pragmas. These changes address issues raised in pull request comments.

---
*PR created automatically by Jules for task [14724657535710353514](https://jules.google.com/task/14724657535710353514) started by @JacobBorden*