### PR TITLE
refactor(matrix): remove dead code and comments

### DIFF
--- a/src/math/matrix.h
+++ b/src/math/matrix.h
@@ -446,13 +446,7 @@ namespace Matrix
 			if (m_Rows > 0 && m_Cols > 0) {
 				for (size_t i = 0; i < m_Rows; i++) // Use size_t for loop
 					m_Data[i] = MatrixRow<T>(m_Cols);
-			} else {
-                // If m_Rows or m_Cols (or both) are 0, m_Size and m_Capacity are already 0
-                // due to the member initializer list. m_Data is also correctly nullptr if m_Rows is 0.
-                // No need to further modify m_Rows or m_Cols here as they are correctly
-                // initialized by the ternary operators in the member initializer list.
-                // Forcing m_Cols to 0 here if m_Rows is 0 (e.g. for a 0xN matrix) was a bug.
-            }
+			}
 		}
 
 		/** @brief Copy constructor (deep copy) for Matrix. */


### PR DESCRIPTION
Removes an empty else branch and related comments from `src/math/matrix.h` around line 450, since they were just explaining a previously fixed bug. No functional changes.

---
*PR created automatically by Jules for task [1706586095684189718](https://jules.google.com/task/1706586095684189718) started by @JacobBorden*