### PR TITLE
🧹 Code Health: Remove commented-out code in neural_pathfinder.cpp

### DIFF
--- a/src/optimization/neural_pathfinder.cpp
+++ b/src/optimization/neural_pathfinder.cpp
@@ -138,18 +138,7 @@ std::vector<AStarPathNode> NeuralPathfinder::FindOptimalPathAStar() {
 
     while (!open_set.empty()) {
         AStarPathNode current_node = open_set.top().second;
-        // double current_node_f_score_in_pq = open_set.top().first; // For debugging
         open_set.pop();
-
-        // If this node was already processed with a better or equal path, skip.
-        // This check is particularly useful if we can update priorities in PQ,
-        // but with std::priority_queue, we add duplicates.
-        // Check against g_score which stores the best known path cost.
-        // double current_node_h_val = CalculateHeuristic(current_node, goal_layer_idx, min_single_edge_cost);
-        // if (current_node_f_score_in_pq > g_score.at(current_node) + current_node_h_val + EPSILON) { // Add EPSILON for float comparisons
-        //    continue; // Stale entry in PQ
-        // }
-        // A simpler check: if a node is popped, its g_score is final for standard A* with consistent heuristic.
 
         if (current_node.layer_idx == goal_layer_idx) {
             return ReconstructPath(came_from, current_node); // Goal reached


### PR DESCRIPTION
🎯 **What:** Removed commented-out code in `src/optimization/neural_pathfinder.cpp` starting around line 144, and an associated debug variable.
💡 **Why:** The commented-out code was no longer needed and cleaning it up improves code maintainability and readability.
✅ **Verification:** Verified changes via `git diff` and ran the full test suite via `ctest`. All 142 tests passed.
✨ **Result:** A cleaner codebase with less clutter.

---
*PR created automatically by Jules for task [11550076974736436987](https://jules.google.com/task/11550076974736436987) started by @JacobBorden*