### PR TITLE
Use random_device seed in Matrix::Randomize

### DIFF
--- a/src/math/matrix.h
+++ b/src/math/matrix.h
@@ -748,8 +748,8 @@ namespace Matrix
 		Matrix<T>& Randomize() // Modified to return reference to self
 		{
             if (!m_Data) return *this; // Do nothing if empty
-			// Seed with system clock for better randomness across runs.
-			static std::mt19937 gen(static_cast<unsigned int>(std::chrono::system_clock::now().time_since_epoch().count()));
+			// Seed with random_device to avoid predictable time-based seeds.
+			static std::mt19937 gen(std::random_device{}());
 			std::uniform_real_distribution<double> dis(-1.0, 1.0); // Use double for distribution
 			for (size_t i = 0; i < m_Rows; ++i)
 			{


### PR DESCRIPTION
What changed:
- Replaced the time-based `std::mt19937` seed in `Matrix<T>::Randomize()` with a seed from `std::random_device`.
- Updated the code comment to describe this as avoiding predictable time-based seeds, not as providing cryptographically secure random values.

Why:
- The previous seed was derived from the system clock, making repeated runs easier to correlate or reproduce by approximate execution time.
- `Randomize()` still uses `std::mt19937` and should not be treated as a CSPRNG or a security-sensitive randomness API.

Verification:
- Pending PR steward rebase and validation on current `master`.

---
*PR created automatically by Jules for task [574203335150113111](https://jules.google.com/task/574203335150113111) started by @JacobBorden*