### PR TITLE
🔒 Fix memory leak on file open failure in save_model

### DIFF
--- a/src/neural_network/neuronet.cpp
+++ b/src/neural_network/neuronet.cpp
@@ -1008,18 +1008,13 @@ bool NeuroNet::NeuroNet::save_model(const std::string& filename) const
 
 	// 3. Write to file
 	std::ofstream ofs(filename);
+	bool success = true;
 	if (!ofs.is_open()) {
-        // NOTE: Potential memory leak here if we return early, as dynamically allocated
-        // JsonValue objects (via new in SetJsonNumber, CreateJsonObjectInObject, etc.)
-        // are not cleaned up by this function. A robust solution would require
-        // a RAII wrapper or a recursive deletion function for the JsonValue structure
-        // if an error occurs after allocations have begun.
-		return false; 
+		success = false;
+	} else {
+		ofs << root.ToString(); // Use the ToString method from custom JsonValue
+		ofs.close();
 	}
-	
-    ofs << root.ToString(); // Use the ToString method from custom JsonValue
-	
-	ofs.close();
 
     // IMPORTANT: Clean up dynamically allocated JsonValue objects.
     // The custom JsonValue::object_value stores JsonValue*. These were allocated with 'new'.
@@ -1048,7 +1043,7 @@ bool NeuroNet::NeuroNet::save_model(const std::string& filename) const
         delete pair.second; // Delete JsonValue* for top-level keys like "input_size", "layer_count", "layers" array itself, "vocabulary_config" object itself
     }
     root.GetObject().clear(); // Clear the map in root to remove dangling pointers
-	return true;
+	return success;
 }
 
 int NeuroNet::NeuroNetLayer::WeightCount() {


### PR DESCRIPTION
🎯 **What:** Fixed a memory leak in `NeuroNet::save_model` that occurred when the function returned early upon failing to open the destination file for writing.

⚠️ **Risk:** The previous implementation returned early on a failure to open the file (`!ofs.is_open()`), bypassing the cleanup logic for dynamically allocated `JsonValue` objects created during serialization. Over time, repeated failures to write to a file could lead to significant memory consumption and potential resource exhaustion (Denial of Service).

🛡️ **Solution:** Removed the early return. Instead, a `success` boolean flag tracks whether the file opened successfully. The function continues to the existing cleanup loop, freeing all dynamically allocated JSON structures, and then returns the `success` status.

---
*PR created automatically by Jules for task [15942941404062636733](https://jules.google.com/task/15942941404062636733) started by @JacobBorden*