### PR TITLE
Refactor GeneticAlgorithm to accept generations as a parameter in run_evolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ This section provides details on the core classes and data structures used in th
     *   **Crossover:** Selected parents are combined to produce "offspring." This involves exchanging genetic material (parts of their flattened weight and bias vectors) with a certain `crossover_rate`. The goal is to combine beneficial traits from different parents.
     *   **Mutation:** Each weight and bias in an offspring's network has a small chance (`mutation_rate`) of being randomly altered. This introduces new genetic variations into the population, helping to avoid premature convergence and explore more of the solution space.
 *   **Key Functionalities:**
-    *   Constructor `GeneticAlgorithm(...)`: Initializes the GA with parameters like population size, mutation rate, crossover rate, number of generations, and a `template_network` which defines the architecture of the individuals.
+    *   Constructor `GeneticAlgorithm(...)`: Initializes the GA with parameters like population size, mutation rate, crossover rate, and a `template_network` which defines the architecture of the individuals.
     *   `initialize_population()`: Creates the initial population of random `NeuroNet` individuals based on the template network.
-    *   `run_evolution(const std::function<double(NeuroNet::NeuroNet&)>& fitness_function)`: Executes the main evolutionary loop for a specified number of generations. This involves repeated cycles of fitness evaluation, selection, crossover, and mutation.
+    *   `run_evolution(int num_generations, const std::function<double(NeuroNet::NeuroNet&)>& fitness_function)`: Executes the main evolutionary loop for a specified number of generations. This involves repeated cycles of fitness evaluation, selection, crossover, and mutation.
     *   `evolve_one_generation(...)`: Carries out a single step of the evolutionary process.
     *   `get_best_individual()`: After the evolution process, this function returns the `NeuroNet` individual that achieved the highest fitness score.
 *   **Source:** Defined in `src/optimization/genetic_algorithm.h`.
@@ -692,13 +692,12 @@ int main() {
         populationSize,
         mutationRate,
         crossoverRate,
-        numGenerations,
         templateNetwork // The configured template network
     );
 
     // d. Run Evolution
     std::cout << "Starting genetic algorithm evolution..." << std::endl;
-    ga.run_evolution(fitness_function);
+    ga.run_evolution(numGenerations, fitness_function);
     std::cout << "Evolution finished." << std::endl;
 
     // e. Get Best Individual

--- a/docs/modules/optimization.md
+++ b/docs/modules/optimization.md
@@ -31,7 +31,7 @@ To provide a ready-to-use genetic algorithm for optimizing the parameters of `Ne
 
 ### Key Functionalities (refer to Doxygen API docs for full details)
 
-*   **Constructor `GeneticAlgorithm(int population_size, double mutation_rate, double crossover_rate, int num_generations, const NeuroNet::NeuroNet& template_network)`:**
+*   **Constructor `GeneticAlgorithm(int population_size, double mutation_rate, double crossover_rate, const NeuroNet::NeuroNet& template_network)`:**
     *   Initializes the GA with essential parameters.
     *   `template_network`: A crucial `NeuroNet` object that defines the fixed architecture (input size, layer count, layer sizes) for all individuals in the population.
 *   **`initialize_population()`:** Creates the initial population. Each `NeuroNet` individual is a copy of the `template_network`'s architecture but with randomly initialized weights and biases.
@@ -40,7 +40,7 @@ To provide a ready-to-use genetic algorithm for optimizing the parameters of `Ne
 *   **`crossover(const NeuroNet::NeuroNet& parent1, const NeuroNet::NeuroNet& parent2)`:** Combines two parent networks to produce two offspring by swapping segments of their flattened weights and biases.
 *   **`mutate(NeuroNet::NeuroNet& individual)`:** Applies random changes to the weights and biases of an individual network.
 *   **`evolve_one_generation(const std::function<double(NeuroNet::NeuroNet&)>& fitness_function, int current_generation_number)`:** Runs a single cycle of evaluation, selection, crossover, and mutation.
-*   **`run_evolution(const std::function<double(NeuroNet::NeuroNet&)>& fitness_function)`:** Executes the main evolutionary loop for the configured number of generations.
+*   **`run_evolution(int num_generations, const std::function<double(NeuroNet::NeuroNet&)>& fitness_function)`:** Executes the main evolutionary loop for the configured number of generations.
 *   **`get_best_individual() const`:** Returns the `NeuroNet` individual with the highest fitness score achieved during the evolution.
 *   **`export_training_metrics_json(const std::string& filename) const`:** Saves training metrics (e.g., fitness per generation) to a JSON file.
 
@@ -85,14 +85,13 @@ The main `README.md` provides a comprehensive example of training a `NeuroNet` u
         populationSize,
         mutationRate,
         crossoverRate,
-        numGenerations,
         templateNetwork
     );
     ```
 
 4.  **Running Evolution:**
     ```cpp
-    ga.run_evolution(fitness_function);
+    ga.run_evolution(numGenerations, fitness_function);
     ```
 
 5.  **Getting the Best Individual:**

--- a/examples/basic_usage_export.cpp
+++ b/examples/basic_usage_export.cpp
@@ -228,14 +228,13 @@ int main() {
         population_size,
         mutation_rate,
         crossover_rate,
-        num_generations,
         template_network
     );
     std::cout << "Genetic Algorithm instance created." << std::endl;
 
     // 3. Run Evolution
     std::cout << "Running evolution for " << num_generations << " generations..." << std::endl;
-    ga_instance.run_evolution(xor_fitness_function);
+    ga_instance.run_evolution(num_generations, xor_fitness_function);
     std::cout << "Evolution finished." << std::endl;
 
     // 4. Export Training Metrics

--- a/src/optimization/genetic_algorithm.cpp
+++ b/src/optimization/genetic_algorithm.cpp
@@ -41,12 +41,10 @@ Optimization::GeneticAlgorithm::GeneticAlgorithm(
     int population_size,
     double mutation_rate,
     double crossover_rate,
-    int num_generations,
     const NeuroNet::NeuroNet& template_network)
     : population_size_(population_size),
       mutation_rate_(mutation_rate),
       crossover_rate_(crossover_rate),
-      num_generations_(num_generations),
       template_network_(template_network), // Make a copy of the template network
       best_individual_(template_network), // Initialize best_individual_ with template structure
       best_fitness_score_(std::numeric_limits<double>::lowest()),
@@ -121,7 +119,6 @@ void Optimization::GeneticAlgorithm::initialize_population() {
     // as it will be updated when a better individual is found.
     // Clear previous run data
     current_run_metrics_ = {}; 
-    current_run_metrics_.generation_data.reserve(num_generations_);
 }
 
 /**
@@ -467,7 +464,7 @@ void Optimization::GeneticAlgorithm::evolve_one_generation(
  * It first initializes the population, then iteratively calls `evolve_one_generation`.
  * @param fitness_function The function to evaluate individual fitness.
  */
-void Optimization::GeneticAlgorithm::run_evolution(const std::function<double(NeuroNet::NeuroNet&)>& fitness_function) {
+void Optimization::GeneticAlgorithm::run_evolution(int num_generations, const std::function<double(NeuroNet::NeuroNet&)>& fitness_function) {
     initialize_population(); // Prepare the initial random population and resets metrics.
     current_generation_ = 0; // Ensure generation count starts from 0 for the loop.
 
@@ -484,16 +481,16 @@ void Optimization::GeneticAlgorithm::run_evolution(const std::function<double(Ne
     ss_start << std::put_time(&buf, "%Y-%m-%dT%H:%M:%S%z");
     current_run_metrics_.start_time = ss_start.str();
 
-    current_run_metrics_.total_generations = num_generations_;
+    current_run_metrics_.total_generations = num_generations;
     current_run_metrics_.generation_data.clear(); // Clear any data from previous runs
-    current_run_metrics_.generation_data.reserve(num_generations_);
+    current_run_metrics_.generation_data.reserve(num_generations);
 
 
-    for (int i = 0; i < num_generations_; ++i) {
+    for (int i = 0; i < num_generations; ++i) {
         current_generation_ = i + 1; // Generation numbers are typically 1-indexed for reporting
         evolve_one_generation(fitness_function, current_generation_);
         // Optional: Add logging here to track progress, e.g., best fitness per generation.
-        // std::cout << "Generation " << current_generation_ << "/" << num_generations_
+        // std::cout << "Generation " << current_generation_ << "/" << num_generations
         //           << " - Best Fitness: " << best_fitness_score_ << std::endl;
     }
 

--- a/src/optimization/genetic_algorithm.h
+++ b/src/optimization/genetic_algorithm.h
@@ -35,7 +35,6 @@ public:
      * @param population_size The number of individuals in the population.
      * @param mutation_rate The probability of mutating a gene (e.g., a weight or bias).
      * @param crossover_rate The probability of performing crossover between two parents.
-     * @param num_generations The total number of generations to run the evolution.
      * @param template_network A NeuroNet object configured with the desired layer structure
      *                         (input size, layer sizes). This template is used to create
      *                         new individuals in the population.
@@ -44,7 +43,6 @@ public:
         int population_size,
         double mutation_rate,
         double crossover_rate,
-        int num_generations,
         const NeuroNet::NeuroNet& template_network
     );
 
@@ -99,9 +97,10 @@ public:
     /**
      * @brief Runs the complete evolution process for the specified number of generations.
      * Initializes the population and then iteratively calls evolve_one_generation.
+     * @param num_generations The total number of generations to run the evolution.
      * @param fitness_function The fitness function to evaluate individuals.
      */
-    void run_evolution(const std::function<double(NeuroNet::NeuroNet&)>& fitness_function);
+    void run_evolution(int num_generations, const std::function<double(NeuroNet::NeuroNet&)>& fitness_function);
 
     /**
      * @brief Retrieves the best NeuroNet individual found during the evolution process.
@@ -121,7 +120,6 @@ private:
     int population_size_;       ///< Number of individuals in the population.
     double mutation_rate_;      ///< Probability of mutation for each gene.
     double crossover_rate_;     ///< Probability of performing crossover.
-    int num_generations_;       ///< Total number of generations for evolution.
     NeuroNet::NeuroNet template_network_; ///< Template NeuroNet defining the structure of individuals.
 
     std::vector<NeuroNet::NeuroNet> population_;     ///< Current population of NeuroNet individuals.

--- a/tests/test_benchmarks.cpp
+++ b/tests/test_benchmarks.cpp
@@ -149,7 +149,6 @@ int main() {
         population_size,
         mutation_rate,
         crossover_rate,
-        num_generations_for_benchmark, // Will run only one generation via evolve_one_generation
         small_nn // Use the configured small_nn as template
     );
 
@@ -204,13 +203,13 @@ int main() {
     // and call run_evolution.
     int few_generations = 3;
     Optimization::GeneticAlgorithm ga_run(
-        population_size, mutation_rate, crossover_rate, few_generations, small_nn
+        population_size, mutation_rate, crossover_rate, small_nn
     );
     // run_evolution calls initialize_population and then evolve_one_generation multiple times.
     // The internal timers for evaluate_fitness, selection, crossover, mutate will be called for each generation.
     utilities::Timer run_evol_timer;
     run_evol_timer.start();
-    ga_run.run_evolution(fitness_func);
+    ga_run.run_evolution(few_generations, fitness_func);
     run_evol_timer.stop();
      std::cout << "GA run_evolution() for " << few_generations << " generations (pop size " << population_size 
               << ") took: " << run_evol_timer.elapsed_milliseconds() << " ms (external timer)" << std::endl;

--- a/tests/test_genetic_algorithm.cpp
+++ b/tests/test_genetic_algorithm.cpp
@@ -39,13 +39,13 @@ protected:
 };
 
 TEST_F(GeneticAlgorithmTest, Constructor) {
-    Optimization::GeneticAlgorithm ga(population_size, mutation_rate, crossover_rate, num_generations, template_net);
+    Optimization::GeneticAlgorithm ga(population_size, mutation_rate, crossover_rate, template_net);
     // Test if constructor runs, further state checked by other tests
     SUCCEED();
 }
 
 TEST_F(GeneticAlgorithmTest, InitializePopulation) {
-    Optimization::GeneticAlgorithm ga(population_size, mutation_rate, crossover_rate, num_generations, template_net);
+    Optimization::GeneticAlgorithm ga(population_size, mutation_rate, crossover_rate, template_net);
     ga.initialize_population();
     
     // Population size is implicitly tested by other methods using the population.
@@ -85,7 +85,7 @@ TEST_F(GeneticAlgorithmTest, InitializePopulation) {
 
 
 TEST_F(GeneticAlgorithmTest, EvaluateFitness) {
-    Optimization::GeneticAlgorithm ga(population_size, mutation_rate, crossover_rate, num_generations, template_net);
+    Optimization::GeneticAlgorithm ga(population_size, mutation_rate, crossover_rate, template_net);
     ga.initialize_population();
     ga.evaluate_fitness(simple_fitness_function);
     // No direct way to get all fitness scores to verify,
@@ -96,7 +96,7 @@ TEST_F(GeneticAlgorithmTest, EvaluateFitness) {
 }
 
 TEST_F(GeneticAlgorithmTest, Mutate) {
-    Optimization::GeneticAlgorithm ga(population_size, 1.0, crossover_rate, num_generations, template_net); // 100% mutation
+    Optimization::GeneticAlgorithm ga(population_size, 1.0, crossover_rate, template_net); // 100% mutation
     ga.initialize_population();
     NeuroNet::NeuroNet original_individual = template_net; // Use template as a base
     std::vector<float> original_weights = original_individual.get_all_weights_flat();
@@ -132,7 +132,7 @@ TEST_F(GeneticAlgorithmTest, Mutate) {
 }
 
 TEST_F(GeneticAlgorithmTest, Crossover) {
-    Optimization::GeneticAlgorithm ga(population_size, mutation_rate, 1.0, num_generations, template_net); // 100% crossover
+    Optimization::GeneticAlgorithm ga(population_size, mutation_rate, 1.0, template_net); // 100% crossover
     
     NeuroNet::NeuroNet parent1 = template_net;
     std::vector<float> p1_weights(template_net.get_all_weights_flat().size(), 1.0f); // All 1s
@@ -182,14 +182,14 @@ TEST_F(GeneticAlgorithmTest, RunEvolutionImprovesFitness) {
     // This test is probabilistic and might not always pass if the GA gets stuck
     // or if the problem/fitness function is too complex for few generations.
     // For a simple sum-of-weights fitness, we expect improvement.
-    Optimization::GeneticAlgorithm ga(population_size, mutation_rate, crossover_rate, num_generations, template_net);
+    Optimization::GeneticAlgorithm ga(population_size, mutation_rate, crossover_rate, template_net);
     
     ga.initialize_population();
     ga.evaluate_fitness(simple_fitness_function);
     NeuroNet::NeuroNet initial_best = ga.get_best_individual();
     double initial_best_fitness = simple_fitness_function(initial_best);
 
-    ga.run_evolution(simple_fitness_function);
+    ga.run_evolution(num_generations, simple_fitness_function);
 
     NeuroNet::NeuroNet final_best = ga.get_best_individual();
     double final_best_fitness = simple_fitness_function(final_best);
@@ -203,7 +203,7 @@ TEST_F(GeneticAlgorithmTest, RunEvolutionImprovesFitness) {
 }
 
 TEST_F(GeneticAlgorithmTest, GetBestIndividual) {
-    Optimization::GeneticAlgorithm ga(population_size, mutation_rate, crossover_rate, 1, template_net);
+    Optimization::GeneticAlgorithm ga(population_size, mutation_rate, crossover_rate, template_net);
     ga.initialize_population();
     // Manually create an individual that should be the best
     NeuroNet::NeuroNet clearly_best_net = template_net;
@@ -251,18 +251,13 @@ TEST_F(GeneticAlgorithmTest, GetBestIndividual) {
 #include "../src/utilities/json/json_exception.hpp"
 
 TEST_F(GeneticAlgorithmTest, ExportTrainingMetrics) {
-    Optimization::GeneticAlgorithm ga(population_size, mutation_rate, crossover_rate, num_generations, template_net);
+    Optimization::GeneticAlgorithm ga(population_size, mutation_rate, crossover_rate, template_net);
     
     const int generations_to_run = 2; // Keep it small for test speed
-    // Directly modify num_generations_ of the instance for this test
-    // This is a bit of a hack; ideally, GA would take generations as a run_evolution param or similar
-    // For now, we assume ga.num_generations_ can be set, or we rely on the fixture's num_generations
-    // For this test, let's assume the GA object itself is reconfigured or this test is specific to fixture's num_generations
-    // To make it explicit for the test:
-    Optimization::GeneticAlgorithm ga_test_instance(population_size, mutation_rate, crossover_rate, generations_to_run, template_net);
+    Optimization::GeneticAlgorithm ga_test_instance(population_size, mutation_rate, crossover_rate, template_net);
 
 
-    ga_test_instance.run_evolution(simple_fitness_function);
+    ga_test_instance.run_evolution(generations_to_run, simple_fitness_function);
 
     const std::string metrics_filename = "test_training_metrics_custom.json";
     ASSERT_NO_THROW(ga_test_instance.export_training_metrics_json(metrics_filename));


### PR DESCRIPTION
This PR addresses an issue where the `num_generations` was passed to the `GeneticAlgorithm` constructor and held as an internal state variable. The refactoring instead makes `num_generations` an explicit parameter when calling the `run_evolution` method. This allows an existing `GeneticAlgorithm` instance to cleanly run varying numbers of generations on separate evolution calls without re-instantiating.

- The constructor signature is changed in `src/optimization/genetic_algorithm.h` and `.cpp`.
- The `run_evolution` method signature is changed.
- Documentation and code examples have been updated.
- Benchmarks and unit tests have been updated and are all successfully passing.

---
*PR created automatically by Jules for task [6766763341250922330](https://jules.google.com/task/6766763341250922330) started by @JacobBorden*