### PR TITLE
Fix out-of-range exceptions during weight access in NeuralPathfinder

### DIFF
--- a/src/neural_network/neuronet.cpp
+++ b/src/neural_network/neuronet.cpp
@@ -1084,6 +1084,17 @@ bool NeuroNet::NeuroNetLayer::SetWeights(LayerWeights pWeights) {
 	return true;
 }
 
+// Implementation for NeuroNetLayer::has_weight
+bool NeuroNet::NeuroNetLayer::has_weight(int prev_neuron_idx, int current_neuron_idx_in_layer) const {
+    if (prev_neuron_idx < 0 || static_cast<size_t>(prev_neuron_idx) >= this->WeightMatrix.rows()) {
+        return false;
+    }
+    if (current_neuron_idx_in_layer < 0 || static_cast<size_t>(current_neuron_idx_in_layer) >= this->WeightMatrix.cols()) {
+        return false;
+    }
+    return true;
+}
+
 // Implementation for NeuroNetLayer::get_weight
 float NeuroNet::NeuroNetLayer::get_weight(int prev_neuron_idx, int current_neuron_idx_in_layer) const {
     // WeightMatrix dimensions are InputSize (rows) x vLayerSize (cols).

--- a/src/neural_network/neuronet.h
+++ b/src/neural_network/neuronet.h
@@ -300,6 +300,17 @@ namespace NeuroNet
      */
     float get_weight(int prev_neuron_idx, int current_neuron_idx_in_layer) const;
 
+    /**
+     * @brief Checks if a weight exists connecting a neuron from the previous layer (or input)
+     *        to a neuron in this layer.
+     * @param prev_neuron_idx The index of the neuron in the previous layer (or input feature index).
+     *                        This corresponds to the row in this layer's WeightMatrix.
+     * @param current_neuron_idx_in_layer The index of the neuron in this current layer.
+     *                                   This corresponds to the column in this layer's WeightMatrix.
+     * @return bool True if the weight exists (indices are within bounds), false otherwise.
+     */
+    bool has_weight(int prev_neuron_idx, int current_neuron_idx_in_layer) const;
+
 	private:
 		int vLayerSize = 0; ///< Number of neurons in this layer.
 		int InputSize = 0; ///< Number of inputs expected by this layer.

--- a/src/optimization/neural_pathfinder.cpp
+++ b/src/optimization/neural_pathfinder.cpp
@@ -62,16 +62,14 @@ double NeuralPathfinder::GetMaxAbsoluteWeight() const {
 
         for (int prev_n_idx = 0; prev_n_idx < current_layer_input_size; ++prev_n_idx) {
             for (int curr_n_idx = 0; curr_n_idx < current_layer_neuron_count; ++curr_n_idx) {
-                try {
-                    float weight = layer.get_weight(prev_n_idx, curr_n_idx);
-                    max_abs_weight = std::max(max_abs_weight, std::abs(static_cast<double>(weight)));
-                    weight_found = true;
-                } catch (const std::out_of_range& e) {
+                if (!layer.has_weight(prev_n_idx, curr_n_idx)) {
                     // This might happen if layer configuration is unusual or if there's a bug.
                     // For robustness, could log this error. For now, skip this weight.
-                    // std::cerr << "Warning: Out of range accessing weight in GetMaxAbsoluteWeight: " << e.what() << std::endl;
                     continue;
                 }
+                float weight = layer.get_weight(prev_n_idx, curr_n_idx);
+                max_abs_weight = std::max(max_abs_weight, std::abs(static_cast<double>(weight)));
+                weight_found = true;
             }
         }
     }
@@ -161,16 +159,15 @@ std::vector<AStarPathNode> NeuralPathfinder::FindOptimalPathAStar() {
         // The 'prev_neuron_idx' for next_layer_ref.get_weight is current_node.neuron_idx.
         for (int neighbor_neuron_idx_in_layer = 0; neighbor_neuron_idx_in_layer < num_neurons_in_next_layer; ++neighbor_neuron_idx_in_layer) {
             AStarPathNode neighbor_node(next_layer_idx, neighbor_neuron_idx_in_layer);
-            double weight_val;
-            try {
-                weight_val = static_cast<double>(
-                    next_layer_ref.get_weight(current_node.neuron_idx, neighbor_neuron_idx_in_layer)
-                );
-            } catch (const std::out_of_range& e) {
+
+            if (!next_layer_ref.has_weight(current_node.neuron_idx, neighbor_neuron_idx_in_layer)) {
                 // Should not happen if layer sizes and indices are correct.
-                // std::cerr << "Error accessing weight: " << e.what() << std::endl;
                 continue; // Skip this potential connection
             }
+
+            double weight_val = static_cast<double>(
+                next_layer_ref.get_weight(current_node.neuron_idx, neighbor_neuron_idx_in_layer)
+            );
 
             double edge_cost = -std::log(std::abs(weight_val) + EPSILON);
             double tentative_g_score = g_score.at(current_node) + edge_cost;


### PR DESCRIPTION
Added a bounds-checking `has_weight` method to `NeuroNetLayer` and updated `NeuralPathfinder` to use it instead of expensive `try/catch` blocks that catch `std::out_of_range`. This ensures proper bounds checking without the overhead of exception handling for regular control flow and resolves the reported edge case bug.

---
*PR created automatically by Jules for task [7492521274917145884](https://jules.google.com/task/7492521274917145884) started by @JacobBorden*