### PR TITLE
🔒 Fix potential path traversal vulnerabilities in model and vocabulary loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -953,3 +953,12 @@ The previous mention of Catch2 has been removed as the tests primarily use Googl
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+
+## File Loading Path Policy
+
+For security reasons, functions that load files—such as `NeuroNet::load_model`, `TransformerModel::load_model`, and `Vocabulary::load_from_json`—enforce a strict path policy:
+
+*   **No Absolute Paths:** Paths starting with a root directory separator (`/` or `\`) or a Windows drive letter (e.g., `C:`) are explicitly rejected.
+*   **No Directory Traversal:** Paths containing the sequence `..` are explicitly rejected.
+
+All files must be loaded using **relative paths** that point to locations within the intended working directory structure of the executing application. This policy prevents potential Local File Inclusion (LFI) vulnerabilities where an attacker might attempt to read arbitrary system files.

--- a/src/neural_network/neuronet.cpp
+++ b/src/neural_network/neuronet.cpp
@@ -955,6 +955,11 @@ static void deserialize_layer(NeuroNet::NeuroNet& model, const JsonValue& layer_
 
 NeuroNet::NeuroNet NeuroNet::NeuroNet::load_model(const std::string& filename)
 {
+	if (filename.find("..") != std::string::npos ||
+	    (!filename.empty() && (filename[0] == '/' || filename[0] == '\\' || (filename.length() > 1 && filename[1] == ':')))) {
+		throw std::runtime_error("Invalid filename: Path traversal and absolute paths are not allowed.");
+	}
+
 	std::ifstream ifs(filename);
 	if (!ifs.is_open()) {
 		throw std::runtime_error("Failed to open model file: " + filename);

--- a/src/transformer/transformer_model.cpp
+++ b/src/transformer/transformer_model.cpp
@@ -283,6 +283,11 @@ bool TransformerModel::save_model(const std::string& filename) const { // Fixed 
 
 
 TransformerModel TransformerModel::load_model(const std::string& filename) { // Fixed std::string
+    if (filename.find("..") != std::string::npos ||
+        (!filename.empty() && (filename[0] == '/' || filename[0] == '\\' || (filename.length() > 1 && filename[1] == ':')))) {
+        throw std::runtime_error("Invalid filename: Path traversal and absolute paths are not allowed.");
+    }
+
     std::ifstream ifs(filename); // Fixed std::ifstream
     if (!ifs.is_open()) {
         throw std::runtime_error("Failed to open model file: " + filename); // Fixed std::runtime_error, std::string

--- a/src/utilities/vocabulary.cpp
+++ b/src/utilities/vocabulary.cpp
@@ -32,6 +32,11 @@ std::vector<std::string> Vocabulary::split_by_space(const std::string& str) cons
 }
 
 bool Vocabulary::load_from_json(const std::string& filepath) {
+    if (filepath.find("..") != std::string::npos ||
+        (!filepath.empty() && (filepath[0] == '/' || filepath[0] == '\\' || (filepath.length() > 1 && filepath[1] == ':')))) {
+        return false;
+    }
+
     std::ifstream ifs(filepath);
     if (!ifs.is_open()) {
         // Consider logging an error here

--- a/tests/test_neuronet.cpp
+++ b/tests/test_neuronet.cpp
@@ -938,6 +938,10 @@ TEST_F(NeuroNetTest, Serialization) {
     // 5. Test error handling for load_model
     EXPECT_THROW(NeuroNet::NeuroNet::load_model("non_existent_file.json"), std::runtime_error);
 
+    // Path policy test
+    EXPECT_THROW(NeuroNet::NeuroNet::load_model("../test.json"), std::runtime_error);
+    EXPECT_THROW(NeuroNet::NeuroNet::load_model("/etc/passwd"), std::runtime_error);
+
     // Test with an empty file
     std::ofstream ofs_empty(empty_filename);
     ofs_empty.close();

--- a/tests/test_transformer_model.cpp
+++ b/tests/test_transformer_model.cpp
@@ -21,6 +21,12 @@ protected:
 //     // ASSERT_NE(&model, nullptr);
 // }
 
+TEST_F(TransformerModelTest, LoadModelRejectsUnsafePaths) {
+    EXPECT_THROW(NeuroNet::Transformer::TransformerModel::load_model("../transformer_model.json"), std::runtime_error);
+    EXPECT_THROW(NeuroNet::Transformer::TransformerModel::load_model("/tmp/transformer_model.json"), std::runtime_error);
+    EXPECT_THROW(NeuroNet::Transformer::TransformerModel::load_model("C:\\temp\\transformer_model.json"), std::runtime_error);
+}
+
 // Test case for initialization with parameters
 TEST_F(TransformerModelTest, Initialization) {
     const int vocab_size = 1000;

--- a/tests/test_vocabulary.cpp
+++ b/tests/test_vocabulary.cpp
@@ -70,6 +70,12 @@ TEST_F(VocabularyTest, LoadFromJson_SpecialTokenNotInWordMap) {
     EXPECT_FALSE(vocab.load_from_json(test_vocab_path)); // <UNK> not in word_to_token
 }
 
+TEST_F(VocabularyTest, LoadFromJson_RejectsUnsafePaths) {
+    EXPECT_FALSE(vocab.load_from_json("../temp_test_vocab.json"));
+    EXPECT_FALSE(vocab.load_from_json("/tmp/temp_test_vocab.json"));
+    EXPECT_FALSE(vocab.load_from_json("C:\\temp\\temp_test_vocab.json"));
+}
+
 
 TEST_F(VocabularyTest, GetTokenId) {
     CreateTempVocabFile(test_vocab_path, R"({


### PR DESCRIPTION
🎯 **What:** The `load_model` and `load_from_json` methods across the `NeuroNet`, `TransformerModel`, and `Vocabulary` classes lacked validation on the provided filenames, making them vulnerable to path traversal and absolute path injection.

⚠️ **Risk:** An attacker who can influence the `filename` argument could potentially read arbitrary files on the system (Local File Inclusion / LFI) by supplying paths like `../../../../etc/passwd` or `C:\Windows\System32\config\SAM`, exposing sensitive system data or application secrets.

🛡️ **Solution:** Added a robust pre-check in all relevant file loading functions to explicitly reject filenames containing `..` or leading characters indicative of absolute paths (e.g., `/`, `\`, or Windows drive letters). This limits file loading to safe, relative paths intended by the application structure. Tests passing, no existing functionality broken.

---
*PR created automatically by Jules for task [419631950443025604](https://jules.google.com/task/419631950443025604) started by @JacobBorden*