### PR TITLE
🧹 Refactor `main` function in `examples/transformer_usage.cpp`

### DIFF
--- a/examples/transformer_usage.cpp
+++ b/examples/transformer_usage.cpp
@@ -27,6 +27,70 @@ void print_matrix_summary(const Matrix::Matrix<float>& m, const std::string& tit
     if (m.rows() > 2) std::cout << "  ..." << std::endl;
 }
 
+void perform_forward_pass(NeuroNet::Transformer::TransformerModel& model, const Matrix::Matrix<float>& token_id_batch_matrix) {
+    std::cout << "\n4. Performing forward pass (one sequence at a time):" << std::endl;
+    if (token_id_batch_matrix.rows() > 0) {
+        for (size_t i = 0; i < token_id_batch_matrix.rows(); ++i) {
+            // Create a (1, seq_len) matrix for the current sequence
+            Matrix::Matrix<float> single_sequence_tokens(1, token_id_batch_matrix.cols());
+            for(size_t j=0; j < token_id_batch_matrix.cols(); ++j) {
+                single_sequence_tokens[0][j] = token_id_batch_matrix[i][j];
+            }
+
+            std::cout << "  Forward pass for sequence " << i << ":" << std::endl;
+            print_matrix_summary(single_sequence_tokens, "  Input Token IDs for sequence " + std::to_string(i));
+
+            // Create a dummy attention mask (no masking) for this example
+            // A real mask might be (seq_len, seq_len)
+            Matrix::Matrix<float> dummy_attention_mask(0,0); // Empty mask = no mask in attention layer
+
+            try {
+                Matrix::Matrix<float> output_embeddings = model.forward(single_sequence_tokens, dummy_attention_mask);
+                print_matrix_summary(output_embeddings, "  Output Embeddings for sequence " + std::to_string(i));
+            } catch (const std::exception& e) {
+                std::cerr << "  ERROR during forward pass for sequence " << i << ": " << e.what() << std::endl;
+            }
+        }
+    }
+}
+
+void test_save_and_load_model(NeuroNet::Transformer::TransformerModel& model, const std::string& model_save_filepath, const Matrix::Matrix<float>& token_id_batch_matrix) {
+    std::cout << "\n5. Saving model to " << model_save_filepath << "..." << std::endl;
+    if (model.save_model(model_save_filepath)) {
+        std::cout << "   Model saved successfully." << std::endl;
+
+        // --- 6. Load Model ---
+        std::cout << "\n6. Loading model from " << model_save_filepath << "..." << std::endl;
+        try {
+            NeuroNet::Transformer::TransformerModel loaded_model = NeuroNet::Transformer::TransformerModel::load_model(model_save_filepath);
+            std::cout << "   Model loaded successfully." << std::endl;
+            std::cout << "   Loaded Model Vocab Size: " << loaded_model.get_vocab_size() << std::endl;
+            std::cout << "   Loaded Model D_Model: " << loaded_model.get_d_model() << std::endl;
+
+            // --- Optional: Test loaded model with the first sequence ---
+            if (token_id_batch_matrix.rows() > 0) {
+                 Matrix::Matrix<float> first_sequence_tokens(1, token_id_batch_matrix.cols());
+                 for(size_t j=0; j < token_id_batch_matrix.cols(); ++j) {
+                     first_sequence_tokens[0][j] = token_id_batch_matrix[0][j];
+                 }
+                std::cout << "   Testing loaded model with first sequence..." << std::endl;
+                Matrix::Matrix<float> loaded_model_output = loaded_model.forward(first_sequence_tokens);
+                print_matrix_summary(loaded_model_output, "   Output from loaded model (first sequence)");
+                // For a true test, one would compare this output to the original model's output
+                // if the random initialization was seeded or if weights were deterministic.
+            }
+
+        } catch (const std::exception& e) {
+            std::cerr << "   ERROR: Failed to load or test model: " << e.what() << std::endl;
+        }
+        std::remove(model_save_filepath.c_str()); // Clean up saved model file
+        std::cout << "   Cleaned up temporary model file: " << model_save_filepath << std::endl;
+
+    } else {
+        std::cerr << "   ERROR: Failed to save model." << std::endl;
+    }
+}
+
 // Helper to create a dummy vocabulary JSON file for the example
 bool create_dummy_vocab_file(const std::string& filepath, int vocab_size, int& pad_id, int& unk_id) {
     pad_id = vocab_size - 1; // Assign last ID to PAD
@@ -123,67 +187,10 @@ int main() {
 
 
     // --- 4. Forward Pass (one sequence at a time, as model.forward expects 1xN) ---
-    std::cout << "\n4. Performing forward pass (one sequence at a time):" << std::endl;
-    if (token_id_batch_matrix.rows() > 0) {
-        for (size_t i = 0; i < token_id_batch_matrix.rows(); ++i) {
-            // Create a (1, seq_len) matrix for the current sequence
-            Matrix::Matrix<float> single_sequence_tokens(1, token_id_batch_matrix.cols());
-            for(size_t j=0; j < token_id_batch_matrix.cols(); ++j) {
-                single_sequence_tokens[0][j] = token_id_batch_matrix[i][j];
-            }
+    perform_forward_pass(model, token_id_batch_matrix);
 
-            std::cout << "  Forward pass for sequence " << i << ":" << std::endl;
-            print_matrix_summary(single_sequence_tokens, "  Input Token IDs for sequence " + std::to_string(i));
-
-            // Create a dummy attention mask (no masking) for this example
-            // A real mask might be (seq_len, seq_len)
-            Matrix::Matrix<float> dummy_attention_mask(0,0); // Empty mask = no mask in attention layer
-
-            try {
-                Matrix::Matrix<float> output_embeddings = model.forward(single_sequence_tokens, dummy_attention_mask);
-                print_matrix_summary(output_embeddings, "  Output Embeddings for sequence " + std::to_string(i));
-            } catch (const std::exception& e) {
-                std::cerr << "  ERROR during forward pass for sequence " << i << ": " << e.what() << std::endl;
-            }
-        }
-    }
-
-
-    // --- 5. Save Model ---
-    std::cout << "\n5. Saving model to " << model_save_filepath << "..." << std::endl;
-    if (model.save_model(model_save_filepath)) {
-        std::cout << "   Model saved successfully." << std::endl;
-
-        // --- 6. Load Model ---
-        std::cout << "\n6. Loading model from " << model_save_filepath << "..." << std::endl;
-        try {
-            NeuroNet::Transformer::TransformerModel loaded_model = NeuroNet::Transformer::TransformerModel::load_model(model_save_filepath);
-            std::cout << "   Model loaded successfully." << std::endl;
-            std::cout << "   Loaded Model Vocab Size: " << loaded_model.get_vocab_size() << std::endl;
-            std::cout << "   Loaded Model D_Model: " << loaded_model.get_d_model() << std::endl;
-
-            // --- Optional: Test loaded model with the first sequence ---
-            if (token_id_batch_matrix.rows() > 0) {
-                 Matrix::Matrix<float> first_sequence_tokens(1, token_id_batch_matrix.cols());
-                 for(size_t j=0; j < token_id_batch_matrix.cols(); ++j) {
-                     first_sequence_tokens[0][j] = token_id_batch_matrix[0][j];
-                 }
-                std::cout << "   Testing loaded model with first sequence..." << std::endl;
-                Matrix::Matrix<float> loaded_model_output = loaded_model.forward(first_sequence_tokens);
-                print_matrix_summary(loaded_model_output, "   Output from loaded model (first sequence)");
-                // For a true test, one would compare this output to the original model's output
-                // if the random initialization was seeded or if weights were deterministic.
-            }
-
-        } catch (const std::exception& e) {
-            std::cerr << "   ERROR: Failed to load or test model: " << e.what() << std::endl;
-        }
-        std::remove(model_save_filepath.c_str()); // Clean up saved model file
-        std::cout << "   Cleaned up temporary model file: " << model_save_filepath << std::endl;
-
-    } else {
-        std::cerr << "   ERROR: Failed to save model." << std::endl;
-    }
+    // --- 5. Save and Load Model ---
+    test_save_and_load_model(model, model_save_filepath, token_id_batch_matrix);
 
     // --- Cleanup ---
     std::remove(vocab_filepath.c_str()); // Clean up dummy vocab file


### PR DESCRIPTION
🎯 **What:** Extracted forward pass logic and save/load logic from the overly long `main` function in `examples/transformer_usage.cpp` into separate, dedicated helper functions (`perform_forward_pass` and `test_save_and_load_model`).

💡 **Why:** To improve the maintainability and readability of the example code. The `main` function was becoming difficult to read due to its length and the amount of distinct logical operations it contained. Breaking it down into helper functions makes the code more modular and easier to understand.

✅ **Verification:** Recompiled the project using CMake and ran the full test suite using `ctest --output-on-failure` to ensure that no functionality was broken. Verified that the `transformer_usage` executable still compiles and works exactly as before. Requesting code review yielded a #Correct# rating.

✨ **Result:** A cleaner, more readable `main` function that clearly outlines the high-level steps of the example, with detailed logic properly encapsulated in helper functions.

---
*PR created automatically by Jules for task [12177534094649052559](https://jules.google.com/task/12177534094649052559) started by @JacobBorden*