### PR TITLE
🧹 Refactor UpdateWeights in NeuroNet to improve readability

### DIFF
--- a/src/neural_network/neuronet.cpp
+++ b/src/neural_network/neuronet.cpp
@@ -89,6 +89,101 @@ std::string NeuroNet::NeuroNetLayer::get_activation_function_name() const {
     }
 }
 
+
+void NeuroNet::NeuroNetLayer::UpdateWeights(float learning_rate, int layer_input_size) {
+    int layer_output_size = this->LayerSize();
+
+    // --- Handle Weights ---
+    LayerWeights current_lw_struct = this->get_weights();
+    Matrix::Matrix<float> dLdW_matrix = this->get_dLdW();
+
+    if (current_lw_struct.WeightCount > 0) {
+        if (dLdW_matrix.rows() == 0 && dLdW_matrix.cols() == 0 && layer_input_size == 0 && layer_output_size == 0) {
+            // Special case: layer has 0 input/output size, dLdW might be 0x0 legitimately. Skip update.
+        } else if (dLdW_matrix.rows() != static_cast<size_t>(layer_input_size) || dLdW_matrix.cols() != static_cast<size_t>(layer_output_size)) {
+             throw std::runtime_error("Dimension mismatch for weight gradients in layer. Expected (" + std::to_string(layer_input_size) + "," + std::to_string(layer_output_size) +
+                                      "), Got (" + std::to_string(dLdW_matrix.rows()) + "," + std::to_string(dLdW_matrix.cols()) + ")");
+        }
+        if (static_cast<int>(dLdW_matrix.rows() * dLdW_matrix.cols()) != current_lw_struct.WeightCount) {
+             throw std::runtime_error("Mismatch between dLdW_matrix total elements (" + std::to_string(dLdW_matrix.rows() * dLdW_matrix.cols()) +
+                                      ") and layer's WeightCount (" + std::to_string(current_lw_struct.WeightCount) +")");
+        }
+
+        Matrix::Matrix<float> current_weights_matrix(layer_input_size, layer_output_size);
+        if (layer_input_size > 0 && layer_output_size > 0) { // Only construct if dimensions are valid
+            int k_w = 0;
+            for (int r = 0; r < layer_input_size; ++r) {
+                for (int c = 0; c < layer_output_size; ++c) {
+                    if (k_w < current_lw_struct.WeightCount) {
+                        current_weights_matrix[r][c] = current_lw_struct.WeightsVector[k_w++];
+                    } else {
+                        throw std::runtime_error("WeightCount mismatch during weight matrix reconstruction");
+                    }
+                }
+            }
+        }
+
+        Matrix::Matrix<float> updated_weights_matrix = current_weights_matrix - (dLdW_matrix * learning_rate);
+
+        LayerWeights new_lw_struct;
+        new_lw_struct.WeightCount = current_lw_struct.WeightCount;
+        if (new_lw_struct.WeightCount > 0) { // Only fill vector if there are weights
+            new_lw_struct.WeightsVector.reserve(new_lw_struct.WeightCount);
+            for (size_t r = 0; r < updated_weights_matrix.rows(); ++r) {
+                for (size_t c = 0; c < updated_weights_matrix.cols(); ++c) {
+                    new_lw_struct.WeightsVector.push_back(updated_weights_matrix[r][c]);
+                }
+            }
+        }
+        if (!this->SetWeights(new_lw_struct)) {
+            throw std::runtime_error("Failed to set updated weights for layer");
+        }
+    }
+
+    // --- Handle Biases ---
+    LayerBiases current_lb_struct = this->get_biases();
+    Matrix::Matrix<float> dLdB_matrix = this->get_dLdB();
+
+    if (current_lb_struct.BiasCount > 0) {
+         if (dLdB_matrix.rows() == 0 && dLdB_matrix.cols() == 0 && layer_output_size == 0) {
+            // Special case: layer has 0 output size, dLdB might be 0x0 legitimately. Skip update.
+         } else if (dLdB_matrix.rows() != 1 || dLdB_matrix.cols() != static_cast<size_t>(layer_output_size)) {
+             throw std::runtime_error("Dimension mismatch for bias gradients in layer. Expected (1," + std::to_string(layer_output_size) +
+                                      "), Got (" + std::to_string(dLdB_matrix.rows()) + "," + std::to_string(dLdB_matrix.cols()) + ")");
+        }
+        if (static_cast<int>(dLdB_matrix.rows() * dLdB_matrix.cols()) != current_lb_struct.BiasCount) {
+             throw std::runtime_error("Mismatch between dLdB_matrix total elements (" + std::to_string(dLdB_matrix.rows() * dLdB_matrix.cols()) +
+                                      ") and layer's BiasCount (" + std::to_string(current_lb_struct.BiasCount) + ")");
+        }
+
+        Matrix::Matrix<float> current_biases_matrix(1, layer_output_size);
+        if (layer_output_size > 0) { // Only construct if dimensions are valid
+            int k_b = 0;
+            for (int c = 0; c < layer_output_size; ++c) {
+                 if (k_b < current_lb_struct.BiasCount) {
+                    current_biases_matrix[0][c] = current_lb_struct.BiasVector[k_b++];
+                 } else {
+                    throw std::runtime_error("BiasCount mismatch during bias matrix reconstruction for layer");
+                 }
+            }
+        }
+
+        Matrix::Matrix<float> updated_biases_matrix = current_biases_matrix - (dLdB_matrix * learning_rate);
+
+        LayerBiases new_lb_struct;
+        new_lb_struct.BiasCount = current_lb_struct.BiasCount;
+        if (new_lb_struct.BiasCount > 0) { // Only fill vector if there are biases
+            new_lb_struct.BiasVector.reserve(new_lb_struct.BiasCount);
+            for (size_t c = 0; c < updated_biases_matrix.cols(); ++c) {
+                new_lb_struct.BiasVector.push_back(updated_biases_matrix[0][c]);
+            }
+        }
+        if (!this->SetBiases(new_lb_struct)) {
+            throw std::runtime_error("Failed to set updated biases for layer");
+        }
+    }
+}
+
 void NeuroNet::NeuroNet::UpdateWeights(float learning_rate) {
     if (learning_rate <= 0.0f) {
         // Optional: throw std::invalid_argument("Learning rate must be positive.");
@@ -114,98 +209,11 @@ void NeuroNet::NeuroNet::UpdateWeights(float learning_rate) {
             }
             layer_input_size = this->NeuroNetVector[i-1].LayerSize();
         }
-        int layer_output_size = layer.LayerSize();
 
-        // --- Handle Weights ---
-        LayerWeights current_lw_struct = layer.get_weights();
-        Matrix::Matrix<float> dLdW_matrix = layer.get_dLdW();
-
-        if (current_lw_struct.WeightCount > 0) {
-            if (dLdW_matrix.rows() == 0 && dLdW_matrix.cols() == 0 && layer_input_size == 0 && layer_output_size == 0) {
-                // Special case: layer has 0 input/output size, dLdW might be 0x0 legitimately. Skip update.
-            } else if (dLdW_matrix.rows() != static_cast<size_t>(layer_input_size) || dLdW_matrix.cols() != static_cast<size_t>(layer_output_size)) {
-                 throw std::runtime_error("Dimension mismatch for weight gradients in layer " + std::to_string(i) +
-                                          ". Expected (" + std::to_string(layer_input_size) + "," + std::to_string(layer_output_size) +
-                                          "), Got (" + std::to_string(dLdW_matrix.rows()) + "," + std::to_string(dLdW_matrix.cols()) + ")");
-            }
-            if (static_cast<int>(dLdW_matrix.rows() * dLdW_matrix.cols()) != current_lw_struct.WeightCount) {
-                 throw std::runtime_error("Mismatch between dLdW_matrix total elements (" + std::to_string(dLdW_matrix.rows() * dLdW_matrix.cols()) +
-                                          ") and layer's WeightCount (" + std::to_string(current_lw_struct.WeightCount) +") for layer " + std::to_string(i));
-            }
-
-            Matrix::Matrix<float> current_weights_matrix(layer_input_size, layer_output_size);
-            if (layer_input_size > 0 && layer_output_size > 0) { // Only construct if dimensions are valid
-                int k_w = 0;
-                for (int r = 0; r < layer_input_size; ++r) {
-                    for (int c = 0; c < layer_output_size; ++c) {
-                        if (k_w < current_lw_struct.WeightCount) {
-                            current_weights_matrix[r][c] = current_lw_struct.WeightsVector[k_w++];
-                        } else {
-                            throw std::runtime_error("WeightCount mismatch during weight matrix reconstruction for layer " + std::to_string(i));
-                        }
-                    }
-                }
-            }
-
-            Matrix::Matrix<float> updated_weights_matrix = current_weights_matrix - (dLdW_matrix * learning_rate);
-
-            LayerWeights new_lw_struct;
-            new_lw_struct.WeightCount = current_lw_struct.WeightCount;
-            if (new_lw_struct.WeightCount > 0) { // Only fill vector if there are weights
-                new_lw_struct.WeightsVector.reserve(new_lw_struct.WeightCount);
-                for (size_t r = 0; r < updated_weights_matrix.rows(); ++r) {
-                    for (size_t c = 0; c < updated_weights_matrix.cols(); ++c) {
-                        new_lw_struct.WeightsVector.push_back(updated_weights_matrix[r][c]);
-                    }
-                }
-            }
-            if (!layer.SetWeights(new_lw_struct)) {
-                throw std::runtime_error("Failed to set updated weights for layer " + std::to_string(i));
-            }
-        }
-
-        // --- Handle Biases ---
-        LayerBiases current_lb_struct = layer.get_biases();
-        Matrix::Matrix<float> dLdB_matrix = layer.get_dLdB();
-
-        if (current_lb_struct.BiasCount > 0) {
-             if (dLdB_matrix.rows() == 0 && dLdB_matrix.cols() == 0 && layer_output_size == 0) {
-                // Special case: layer has 0 output size, dLdB might be 0x0 legitimately. Skip update.
-             } else if (dLdB_matrix.rows() != 1 || dLdB_matrix.cols() != static_cast<size_t>(layer_output_size)) {
-                 throw std::runtime_error("Dimension mismatch for bias gradients in layer " + std::to_string(i) +
-                                          ". Expected (1," + std::to_string(layer_output_size) +
-                                          "), Got (" + std::to_string(dLdB_matrix.rows()) + "," + std::to_string(dLdB_matrix.cols()) + ")");
-            }
-            if (static_cast<int>(dLdB_matrix.rows() * dLdB_matrix.cols()) != current_lb_struct.BiasCount) {
-                 throw std::runtime_error("Mismatch between dLdB_matrix total elements (" + std::to_string(dLdB_matrix.rows() * dLdB_matrix.cols()) +
-                                          ") and layer's BiasCount (" + std::to_string(current_lb_struct.BiasCount) + ") for layer " + std::to_string(i));
-            }
-
-            Matrix::Matrix<float> current_biases_matrix(1, layer_output_size);
-            if (layer_output_size > 0) { // Only construct if dimensions are valid
-                int k_b = 0;
-                for (int c = 0; c < layer_output_size; ++c) {
-                     if (k_b < current_lb_struct.BiasCount) {
-                        current_biases_matrix[0][c] = current_lb_struct.BiasVector[k_b++];
-                     } else {
-                        throw std::runtime_error("BiasCount mismatch during bias matrix reconstruction for layer " + std::to_string(i));
-                     }
-                }
-            }
-
-            Matrix::Matrix<float> updated_biases_matrix = current_biases_matrix - (dLdB_matrix * learning_rate);
-
-            LayerBiases new_lb_struct;
-            new_lb_struct.BiasCount = current_lb_struct.BiasCount;
-            if (new_lb_struct.BiasCount > 0) { // Only fill vector if there are biases
-                new_lb_struct.BiasVector.reserve(new_lb_struct.BiasCount);
-                for (size_t c = 0; c < updated_biases_matrix.cols(); ++c) {
-                    new_lb_struct.BiasVector.push_back(updated_biases_matrix[0][c]);
-                }
-            }
-            if (!layer.SetBiases(new_lb_struct)) {
-                throw std::runtime_error("Failed to set updated biases for layer " + std::to_string(i));
-            }
+        try {
+            layer.UpdateWeights(learning_rate, layer_input_size);
+        } catch (const std::exception& e) {
+            throw std::runtime_error(std::string(e.what()) + " in layer " + std::to_string(i));
         }
     }
 }

--- a/src/neural_network/neuronet.h
+++ b/src/neural_network/neuronet.h
@@ -107,6 +107,8 @@ namespace NeuroNet
 		 */
 		Matrix::Matrix<float> ReturnOutputMatrix();
 
+		void UpdateWeights(float learning_rate, int layer_input_size);
+
 		/**
 		 * @brief Sets the input for this layer.
 		 * @param pInputMatrix A const reference to a matrix containing the input values. Must match the expected input dimensions.


### PR DESCRIPTION
🎯 **What:** The overly long function `NeuroNet::NeuroNet::UpdateWeights` in `neuronet.cpp` was refactored by extracting the logic that updates individual layer weights into a new method `NeuroNetLayer::UpdateWeights`.
💡 **Why:** This improves the maintainability and readability of the codebase. The `NeuroNet::UpdateWeights` function now cleanly iterates over its layers and calls `layer.UpdateWeights`, delegating the complex per-layer weight and bias matrix updates to the layer class itself. This is more encapsulated and cohesive.
✅ **Verification:** Compiled the project and ran the full test suite (`ctest --output-on-failure`), ensuring all 142 tests continue to pass correctly. The logic for exception handling was preserved precisely by wrapping the layer calls in a try-catch to append the layer index, mirroring the previous behavior.
✨ **Result:** The codebase is cleaner and `neuronet.cpp` is more readable without introducing any regressions.

---
*PR created automatically by Jules for task [16655960170652757347](https://jules.google.com/task/16655960170652757347) started by @JacobBorden*