### PR TITLE
🧹 Refactor long main function in basic_usage_export.cpp

### DIFF
--- a/examples/basic_usage_export.cpp
+++ b/examples/basic_usage_export.cpp
@@ -192,7 +192,112 @@ std::function<double(NeuroNet::NeuroNet&)> xor_fitness_function =
 };
 
 
-int main() {
+void run_vocabulary_demo(NeuroNet::NeuroNet& best_model) {
+    std::cout << "\n--- Demonstrating String Input and Vocabulary Features ---" << std::endl;
+
+    // 1. Define and create a sample vocabulary JSON file for the example
+    const std::string example_vocab_filepath = "example_vocabulary.json";
+    std::ofstream vocab_file(example_vocab_filepath);
+    if (vocab_file.is_open()) {
+        vocab_file << R"({
+            "word_to_token": {
+                "hello": 0, "world": 1, "neuronet": 2, "example": 3,
+                "<UNK>": 4, "<PAD>": 5
+            },
+            "token_to_word": {
+                "0": "hello", "1": "world", "2": "neuronet", "3": "example",
+                "4": "<UNK>", "5": "<PAD>"
+            },
+            "special_tokens": {
+                "unknown_token": "<UNK>",
+                "padding_token": "<PAD>"
+            },
+            "config": {
+                "max_sequence_length": 5
+            }
+        })";
+        vocab_file.close();
+        std::cout << "Sample vocabulary file created: " << example_vocab_filepath << std::endl;
+    } else {
+        std::cerr << "Failed to create sample vocabulary file for example." << std::endl;
+    }
+
+    // We'll use the 'best_model' from the GA, but reconfigure its InputSize
+    // and load the new vocabulary for demonstration purposes.
+    // Its existing weights won't be meaningful for string inputs with this new vocab.
+    // Note: best_model is a copy of the GA's best individual. Modifying it here is fine for demo.
+
+    // 2. Load the vocabulary
+    bool vocab_loaded = false;
+    try {
+        vocab_loaded = best_model.LoadVocabulary(example_vocab_filepath);
+    } catch (const std::exception& e) {
+        std::cerr << "Exception during LoadVocabulary: " << e.what() << std::endl;
+    }
+
+    if (vocab_loaded) {
+        std::cout << "Vocabulary loaded successfully." << std::endl;
+        const auto& loaded_vocab_obj = best_model.getVocabulary(); // Use the new getter
+        std::cout << "  Vocabulary's max_sequence_length: " << loaded_vocab_obj.get_max_sequence_length() << std::endl;
+        std::cout << "  <UNK> token ID: " << loaded_vocab_obj.get_unknown_token_id() << std::endl;
+        std::cout << "  <PAD> token ID: " << loaded_vocab_obj.get_padding_token_id() << std::endl;
+
+
+        // 3. Reconfigure network's InputSize to match vocabulary's max_sequence_length for this demo
+        int required_input_size = loaded_vocab_obj.get_max_sequence_length();
+        if (required_input_size <= 0) {
+             std::cout << "Vocabulary max_sequence_length is not positive, defaulting to 5 for demo." << std::endl;
+             required_input_size = 5; // Fallback for demo if not in vocab file
+        }
+
+        std::cout << "Setting network InputSize to: " << required_input_size << " to match vocab's max_sequence_length for demo." << std::endl;
+        best_model.SetInputSize(required_input_size);
+
+        // Resizing layers to be compatible with the new InputSize.
+        // For simplicity, let's assume the first layer's number of neurons can remain the same.
+        // The internal weight matrix of the first layer will be re-initialized by ResizeLayer.
+        if (best_model.getLayerCount() > 0) {
+             std::cout << "Re-initializing first layer with new InputSize." << std::endl;
+             best_model.ResizeLayer(0, best_model.getLayer(0).LayerSize());
+        }
+
+
+        // 4. Prepare and set string input using SetStringsInput
+        const std::string string_input_json = R"({
+            "input_batch": [
+                "hello world neuronet",   // 3 tokens
+                "an unknown example",     // 3 tokens, "an" will be <UNK>
+                "hello world again test"  // 4 tokens, "again", "test" are <UNK>
+            ]
+        })";
+        std::cout << "Attempting to set string input: " << string_input_json << std::endl;
+
+        try {
+            // SetStringsInput will use the max_sequence_length from the loaded vocabulary (5)
+            // So, sequences will be padded/truncated to 5 tokens.
+            if (best_model.SetStringsInput(string_input_json)) {
+                std::cout << "SetStringsInput successful." << std::endl;
+
+                // 5. Get and display output (as JSON, for consistency with other examples)
+                // The actual numerical output will be based on the (probably unsuitable) XOR weights
+                // or re-initialized weights, but this demonstrates the pipeline.
+                std::string string_net_output_json = best_model.GetOutputJSON();
+                std::cout << "Output from network after string input (JSON): " << string_net_output_json << std::endl;
+            } else {
+                std::cerr << "SetStringsInput failed." << std::endl;
+            }
+        } catch (const std::exception& e) {
+            std::cerr << "Exception during SetStringsInput or GetOutputJSON: " << e.what() << std::endl;
+        }
+    } else {
+        std::cerr << "Failed to load vocabulary for string input demo." << std::endl;
+    }
+    // Clean up the example vocabulary file
+    std::remove(example_vocab_filepath.c_str());
+    std::cout << "Cleaned up temporary vocabulary file: " << example_vocab_filepath << std::endl;
+}
+
+void run_ga_xor_example() {
     std::cout << "Starting NeuroNet Genetic Algorithm XOR Example..." << std::endl;
 
     // 1. Define NeuroNet Structure
@@ -331,114 +436,18 @@ int main() {
             std::cout << "----" << std::endl;
         }
 
-        std::cout << "\n--- Demonstrating String Input and Vocabulary Features ---" << std::endl;
-
-        // 1. Define and create a sample vocabulary JSON file for the example
-        const std::string example_vocab_filepath = "example_vocabulary.json";
-        std::ofstream vocab_file(example_vocab_filepath);
-        if (vocab_file.is_open()) {
-            vocab_file << R"({
-                "word_to_token": {
-                    "hello": 0, "world": 1, "neuronet": 2, "example": 3,
-                    "<UNK>": 4, "<PAD>": 5
-                },
-                "token_to_word": {
-                    "0": "hello", "1": "world", "2": "neuronet", "3": "example",
-                    "4": "<UNK>", "5": "<PAD>"
-                },
-                "special_tokens": {
-                    "unknown_token": "<UNK>",
-                    "padding_token": "<PAD>"
-                },
-                "config": {
-                    "max_sequence_length": 5
-                }
-            })";
-            vocab_file.close();
-            std::cout << "Sample vocabulary file created: " << example_vocab_filepath << std::endl;
-        } else {
-            std::cerr << "Failed to create sample vocabulary file for example." << std::endl;
-        }
-
-        // We'll use the 'best_model' from the GA, but reconfigure its InputSize
-        // and load the new vocabulary for demonstration purposes.
-        // Its existing weights won't be meaningful for string inputs with this new vocab.
-        // Note: best_model is a copy of the GA's best individual. Modifying it here is fine for demo.
-
-        // 2. Load the vocabulary
-        bool vocab_loaded = false;
-        try {
-            vocab_loaded = best_model.LoadVocabulary(example_vocab_filepath);
-        } catch (const std::exception& e) {
-            std::cerr << "Exception during LoadVocabulary: " << e.what() << std::endl;
-        }
-
-        if (vocab_loaded) {
-            std::cout << "Vocabulary loaded successfully." << std::endl;
-            const auto& loaded_vocab_obj = best_model.getVocabulary(); // Use the new getter
-            std::cout << "  Vocabulary's max_sequence_length: " << loaded_vocab_obj.get_max_sequence_length() << std::endl;
-            std::cout << "  <UNK> token ID: " << loaded_vocab_obj.get_unknown_token_id() << std::endl;
-            std::cout << "  <PAD> token ID: " << loaded_vocab_obj.get_padding_token_id() << std::endl;
-
-
-            // 3. Reconfigure network's InputSize to match vocabulary's max_sequence_length for this demo
-            int required_input_size = loaded_vocab_obj.get_max_sequence_length();
-            if (required_input_size <= 0) {
-                 std::cout << "Vocabulary max_sequence_length is not positive, defaulting to 5 for demo." << std::endl;
-                 required_input_size = 5; // Fallback for demo if not in vocab file
-            }
-
-            std::cout << "Setting network InputSize to: " << required_input_size << " to match vocab's max_sequence_length for demo." << std::endl;
-            best_model.SetInputSize(required_input_size);
-
-            // Resizing layers to be compatible with the new InputSize.
-            // For simplicity, let's assume the first layer's number of neurons can remain the same.
-            // The internal weight matrix of the first layer will be re-initialized by ResizeLayer.
-            if (best_model.getLayerCount() > 0) {
-                 std::cout << "Re-initializing first layer with new InputSize." << std::endl;
-                 best_model.ResizeLayer(0, best_model.getLayer(0).LayerSize());
-            }
-
-
-            // 4. Prepare and set string input using SetStringsInput
-            const std::string string_input_json = R"({
-                "input_batch": [
-                    "hello world neuronet",   // 3 tokens
-                    "an unknown example",     // 3 tokens, "an" will be <UNK>
-                    "hello world again test"  // 4 tokens, "again", "test" are <UNK>
-                ]
-            })";
-            std::cout << "Attempting to set string input: " << string_input_json << std::endl;
-
-            try {
-                // SetStringsInput will use the max_sequence_length from the loaded vocabulary (5)
-                // So, sequences will be padded/truncated to 5 tokens.
-                if (best_model.SetStringsInput(string_input_json)) {
-                    std::cout << "SetStringsInput successful." << std::endl;
-
-                    // 5. Get and display output (as JSON, for consistency with other examples)
-                    // The actual numerical output will be based on the (probably unsuitable) XOR weights
-                    // or re-initialized weights, but this demonstrates the pipeline.
-                    std::string string_net_output_json = best_model.GetOutputJSON();
-                    std::cout << "Output from network after string input (JSON): " << string_net_output_json << std::endl;
-                } else {
-                    std::cerr << "SetStringsInput failed." << std::endl;
-                }
-            } catch (const std::exception& e) {
-                std::cerr << "Exception during SetStringsInput or GetOutputJSON: " << e.what() << std::endl;
-            }
-        } else {
-            std::cerr << "Failed to load vocabulary for string input demo." << std::endl;
-        }
-        // Clean up the example vocabulary file
-        std::remove(example_vocab_filepath.c_str());
-        std::cout << "Cleaned up temporary vocabulary file: " << example_vocab_filepath << std::endl;
+        run_vocabulary_demo(best_model);
 
     } else {
         std::cout << "Best model has no layers, cannot save or test." << std::endl;
     }
 
     std::cout << "\nExample finished." << std::endl;
+}
+
+int main() {
+    // Run the GA XOR example
+    run_ga_xor_example();
 
     // Run the A* pathfinding example
     run_astar_pathfinding_example();


### PR DESCRIPTION
🎯 **What**: Extracted long logical blocks from `main` into separate smaller functions (`run_ga_xor_example`, `run_vocabulary_demo`) in `examples/basic_usage_export.cpp`.
💡 **Why**: `main` was overly long and complex, making it difficult to read and maintain. Extracting logic improves code organization.
✅ **Verification**: Compiled the project and ran unit tests via `ctest --output-on-failure` to ensure functionality wasn't impacted.
✨ **Result**: A much cleaner and readable `main` function that acts as a simple driver for example sub-programs.

---
*PR created automatically by Jules for task [1336545434899830553](https://jules.google.com/task/1336545434899830553) started by @JacobBorden*