### PR TITLE
⚡ Bolt: [performance improvement] Cache-friendly loop interchange for matrix multiplication

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-12 - [Cache-friendly Matrix Multiplication]
+**Learning:** The custom `Matrix` implementation uses a row-major array of pointers `std::unique_ptr<MatrixRow<T>[]> m_Data`. The current matrix multiplication `operator*` uses a loop order of `i -> k -> j`. In the innermost loop `j`, it accesses `b.m_Data[j][k]`, which reads down a column. This is not cache-friendly because row-major layout means contiguous memory is along rows, not columns, leading to frequent cache misses.
+**Action:** When working with custom row-major matrix implementations, always use loop interchange to `i -> j -> k` for matrix multiplication to ensure sequential memory access in the innermost loop.

--- a/src/math/matrix.h
+++ b/src/math/matrix.h
@@ -1053,14 +1053,23 @@ namespace Matrix
         // `i` is the loop control variable for the parallel for.
         // `k`, `j`, and `sum` are declared inside the scope of the `i` loop,
         // making them private to each iteration of the outer loop, and thus to each thread handling an `i`.
+		// Explicitly guard OpenMP pragma
+#ifdef _OPENMP
 		#pragma omp parallel for
+#endif
 		for (size_t i = 0; i < m_Rows; i++) {
-			for (size_t k = 0; k < b.m_Cols; k++) { // Iterate over columns of b (which is cols of c)
-                T sum = T(0); // Initialize sum for c[i][k]
-				for (size_t j = 0; j < m_Cols; j++) { // Iterate over columns of a / rows of b
-					sum += m_Data[i][j] * b.m_Data[j][k];
-				}
-                c.m_Data[i][k] = sum; // Each thread writes to a different c.m_Data[i] row part
+            // Initialize the row of the result matrix to 0.
+            // Using assign(T(0)) would be nice, but MatrixRow doesn't have it, so loop it.
+            for (size_t k = 0; k < b.m_Cols; k++) {
+                c.m_Data[i][k] = T(0);
+            }
+            // Loop interchange: i -> j -> k for cache-friendly sequential memory access.
+            // This reads along the contiguous rows of b, vastly improving cache hits.
+            for (size_t j = 0; j < m_Cols; j++) {
+                T a_ij = m_Data[i][j];
+                for (size_t k = 0; k < b.m_Cols; k++) {
+                    c.m_Data[i][k] += a_ij * b.m_Data[j][k];
+                }
             }
         }
 


### PR DESCRIPTION
⚡ Bolt: [performance improvement] Cache-friendly loop interchange for matrix multiplication

💡 What: Changed the matrix multiplication loop order in `src/math/matrix.h` from i-k-j to i-j-k.
🎯 Why: In a row-major matrix layout, the inner loop `j` previously read down the columns of the `b` matrix (`b.m_Data[j][k]`), which causes frequent cache misses. The loop interchange ensures sequential memory access along the contiguous rows.
📊 Impact: Expected to provide a massive speedup (often an order of magnitude) for large matrix multiplications due to maximizing CPU spatial cache locality.
🔬 Measurement: Verify by running the test suite (`ctest`) to ensure no regressions, and benchmark the matrix multiplication with and without the patch.

---
*PR created automatically by Jules for task [7752324127117860267](https://jules.google.com/task/7752324127117860267) started by @JacobBorden*