### PR TITLE
⚡ Bolt: Optimize memory allocation during Matrix operations

### DIFF
--- a/src/neural_network/neuronet.cpp
+++ b/src/neural_network/neuronet.cpp
@@ -138,29 +138,18 @@ void NeuroNet::NeuroNet::UpdateSingleLayerWeights(NeuroNetLayer& layer, int laye
                                       ") and layer's WeightCount (" + std::to_string(current_lw_struct.WeightCount) +") for layer " + std::to_string(layer_index));
         }
 
-        Matrix::Matrix<float> current_weights_matrix(layer_input_size, layer_output_size);
-        if (layer_input_size > 0 && layer_output_size > 0) { // Only construct if dimensions are valid
+        LayerWeights new_lw_struct;
+        new_lw_struct.WeightCount = current_lw_struct.WeightCount;
+        if (new_lw_struct.WeightCount > 0) {
+            new_lw_struct.WeightsVector.reserve(new_lw_struct.WeightCount);
             int k_w = 0;
             for (int r = 0; r < layer_input_size; ++r) {
                 for (int c = 0; c < layer_output_size; ++c) {
                     if (k_w < current_lw_struct.WeightCount) {
-                        current_weights_matrix[r][c] = current_lw_struct.WeightsVector[k_w++];
+                        new_lw_struct.WeightsVector.push_back(current_lw_struct.WeightsVector[k_w++] - dLdW_matrix[r][c] * learning_rate);
                     } else {
-                        throw std::runtime_error("WeightCount mismatch during weight matrix reconstruction for layer " + std::to_string(layer_index));
+                        throw std::runtime_error("WeightCount mismatch during weight update for layer " + std::to_string(layer_index));
                     }
-                }
-            }
-        }
-
-        Matrix::Matrix<float> updated_weights_matrix = current_weights_matrix - (dLdW_matrix * learning_rate);
-
-        LayerWeights new_lw_struct;
-        new_lw_struct.WeightCount = current_lw_struct.WeightCount;
-        if (new_lw_struct.WeightCount > 0) { // Only fill vector if there are weights
-            new_lw_struct.WeightsVector.reserve(new_lw_struct.WeightCount);
-            for (size_t r = 0; r < updated_weights_matrix.rows(); ++r) {
-                for (size_t c = 0; c < updated_weights_matrix.cols(); ++c) {
-                    new_lw_struct.WeightsVector.push_back(updated_weights_matrix[r][c]);
                 }
             }
         }
@@ -187,26 +176,17 @@ void NeuroNet::NeuroNet::UpdateSingleLayerBiases(NeuroNetLayer& layer, int layer
                                       ") and layer's BiasCount (" + std::to_string(current_lb_struct.BiasCount) + ") for layer " + std::to_string(layer_index));
         }
 
-        Matrix::Matrix<float> current_biases_matrix(1, layer_output_size);
-        if (layer_output_size > 0) { // Only construct if dimensions are valid
+        LayerBiases new_lb_struct;
+        new_lb_struct.BiasCount = current_lb_struct.BiasCount;
+        if (new_lb_struct.BiasCount > 0) {
+            new_lb_struct.BiasVector.reserve(new_lb_struct.BiasCount);
             int k_b = 0;
             for (int c = 0; c < layer_output_size; ++c) {
                  if (k_b < current_lb_struct.BiasCount) {
-                    current_biases_matrix[0][c] = current_lb_struct.BiasVector[k_b++];
+                    new_lb_struct.BiasVector.push_back(current_lb_struct.BiasVector[k_b++] - dLdB_matrix[0][c] * learning_rate);
                  } else {
-                    throw std::runtime_error("BiasCount mismatch during bias matrix reconstruction for layer " + std::to_string(layer_index));
+                    throw std::runtime_error("BiasCount mismatch during bias update for layer " + std::to_string(layer_index));
                  }
-            }
-        }
-
-        Matrix::Matrix<float> updated_biases_matrix = current_biases_matrix - (dLdB_matrix * learning_rate);
-
-        LayerBiases new_lb_struct;
-        new_lb_struct.BiasCount = current_lb_struct.BiasCount;
-        if (new_lb_struct.BiasCount > 0) { // Only fill vector if there are biases
-            new_lb_struct.BiasVector.reserve(new_lb_struct.BiasCount);
-            for (size_t c = 0; c < updated_biases_matrix.cols(); ++c) {
-                new_lb_struct.BiasVector.push_back(updated_biases_matrix[0][c]);
             }
         }
         if (!layer.SetBiases(new_lb_struct)) {


### PR DESCRIPTION
💡 What
Replaced intermediate `Matrix::Matrix<float>` operations during weight and bias gradient updates in `NeuroNet::UpdateSingleLayerWeights` and `NeuroNet::UpdateSingleLayerBiases` with inline, element-wise updates directly to the underlying `std::vector` to avoid multiple deep memory copies. Updated `TODO.MD` to reflect the completed item.

🎯 Why
By skipping the creation of temporary matrices for current weights/biases and avoiding the matrix-subtraction operations (which themselves allocate result matrices), we significantly reduce dynamic memory allocations and free/delete cycles during the inner loops of the backpropagation training process.

📊 Impact
Reduces heap allocation overhead and copying time per training step.

🔬 Measurement
All 166 tests pass in Release mode, verifying that the algebraic correctness is preserved.

---
*PR created automatically by Jules for task [16008250818695268590](https://jules.google.com/task/16008250818695268590) started by @JacobBorden*