### PR TITLE
Implement OpenMP parallelization for Softmax activation

### DIFF
--- a/TODO.MD
+++ b/TODO.MD
@@ -5,7 +5,7 @@
 - [ ] Add support for Convolutional Neural Networks (CNNs).
 - [ ] Add support for Recurrent Neural Networks (RNNs) / LSTMs.
 - [x] Optimize memory allocation during Matrix operations (e.g. avoid copies).
-- [ ] Implement better OpenMP parallelization in Neural Network forward pass, not just Matrix multiplication.
+- [x] Implement better OpenMP parallelization in Neural Network forward pass, not just Matrix multiplication.
 - [ ] Create a Python binding / API for the library (e.g., using pybind11).
 - [ ] Expand the Transformer module to include Decoder layers and full Encoder-Decoder models.
 - [ ] Add more comprehensive logging and debug modes.

--- a/src/neural_network/neuronet.cpp
+++ b/src/neural_network/neuronet.cpp
@@ -622,6 +622,9 @@ void NeuroNet::NeuroNetLayer::ApplySoftmax(Matrix::Matrix<float>& output) {
         // this logic would need to be adjusted. For now, it processes a single output vector.
     }
 
+    #ifdef _OPENMP
+    #pragma omp parallel for reduction(+:sum_exp)
+    #endif
     for (size_t j = 0; j < output.cols(); ++j) {
         output[0][j] = std::exp(output[0][j]);
         sum_exp += output[0][j];
@@ -629,6 +632,9 @@ void NeuroNet::NeuroNetLayer::ApplySoftmax(Matrix::Matrix<float>& output) {
 
     // Normalize
     if (sum_exp != 0.0f) { // Avoid division by zero
+        #ifdef _OPENMP
+        #pragma omp parallel for
+        #endif
         for (size_t j = 0; j < output.cols(); ++j) {
             output[0][j] /= sum_exp;
         }

--- a/tests/test_genetic_algorithm.cpp
+++ b/tests/test_genetic_algorithm.cpp
@@ -156,26 +156,18 @@ TEST_F(GeneticAlgorithmTest, Crossover) {
     std::vector<float> o1_weights = offspring[0].get_all_weights_flat();
     std::vector<float> o2_weights = offspring[1].get_all_weights_flat();
 
-    bool p1_material_in_o1 = false;
-    bool p2_material_in_o1 = false;
-    bool p1_material_in_o2 = false;
-    bool p2_material_in_o2 = false;
-
     if (!o1_weights.empty()) {
-        for(float w : o1_weights) {
-            if (w == 1.0f) p1_material_in_o1 = true;
-            if (w == 2.0f) p2_material_in_o1 = true;
+        ASSERT_EQ(o1_weights.size(), o2_weights.size());
+        bool swapped_material = false;
+        for (size_t i = 0; i < o1_weights.size(); ++i) {
+            const bool original_order = (o1_weights[i] == 1.0f && o2_weights[i] == 2.0f);
+            const bool swapped_order = (o1_weights[i] == 2.0f && o2_weights[i] == 1.0f);
+            EXPECT_TRUE(original_order || swapped_order);
+            swapped_material = swapped_material || swapped_order;
         }
-        for(float w : o2_weights) {
-            if (w == 1.0f) p1_material_in_o2 = true;
-            if (w == 2.0f) p2_material_in_o2 = true;
-        }
-        // Single point crossover means one offspring will have start of P1, end of P2
-        // and other will have start of P2, end of P1. So both should have material from both.
-        EXPECT_TRUE(p1_material_in_o1);
-        EXPECT_TRUE(p2_material_in_o1);
-        EXPECT_TRUE(p1_material_in_o2);
-        EXPECT_TRUE(p2_material_in_o2);
+        // A crossover point at 0 legitimately swaps the whole vector, so only require
+        // complementary parent material and at least one swapped position.
+        EXPECT_TRUE(swapped_material);
     } else {
         SUCCEED(); // No weights to crossover
     }
@@ -193,7 +185,11 @@ TEST_F(GeneticAlgorithmTest, RunEvolutionImprovesFitness) {
     NeuroNet::NeuroNet initial_best = ga.get_best_individual();
     double initial_best_fitness = simple_fitness_function(initial_best);
 
-    ga.run_evolution(simple_fitness_function);
+    // Evolve the already-evaluated population so the comparison is against the
+    // same initial population. run_evolution() intentionally reinitializes.
+    for (int generation = 1; generation <= num_generations; ++generation) {
+        ga.evolve_one_generation(simple_fitness_function, generation);
+    }
 
     NeuroNet::NeuroNet final_best = ga.get_best_individual();
     double final_best_fitness = simple_fitness_function(final_best);


### PR DESCRIPTION
This PR completes the TODO item: "Implement better OpenMP parallelization in Neural Network forward pass, not just Matrix multiplication."

It achieves this by adding OpenMP parallelization to the `ApplySoftmax` function within `NeuroNetLayer`. Specifically, it uses a parallel reduction to safely compute the sum of exponents and a parallel for loop for the subsequent normalization step. This ensures that the forward pass is better parallelized beyond just the core matrix multiplications. The TODO list in `TODO.MD` has been updated to reflect this completion.

Steward update:
- Rebased the branch onto current `master` after #107 merged.
- Added test-only stabilization for the known flaky GA tests tracked by #80: `GeneticAlgorithmTest.Crossover` now accepts the valid full-vector crossover case, and `GeneticAlgorithmTest.RunEvolutionImprovesFitness` now compares evolution within the same initialized population.

Validation:
- Local `cmake --build build --config Release` passed.
- Local `ctest --test-dir build -C Release --output-on-failure` passed with 299/299 tests.
- Local repeated `GeneticAlgorithmTest.Crossover` and `GeneticAlgorithmTest.RunEvolutionImprovesFitness` runs passed 25 iterations.
- Fresh GitHub CMake build and Doxygen checks passed on `843b61f`.

---
*PR created automatically by Jules for task [4333760644469471102](https://jules.google.com/task/4333760644469471102) started by @JacobBorden*