### PR TITLE
Add MNIST Dataset Loader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(neuronet STATIC
     src/utilities/json/json.cpp
     src/utilities/timer.cpp
     src/utilities/vocabulary.cpp
+    src/utilities/dataset_loader.cpp
     src/transformer/attention.cpp
     src/transformer/embedding.cpp
     src/transformer/multi_head_attention.cpp

--- a/TODO.MD
+++ b/TODO.MD
@@ -10,5 +10,5 @@
 - [ ] Expand the Transformer module to include Decoder layers and full Encoder-Decoder models.
 - [ ] Add more comprehensive logging and debug modes.
 - [x] Implement early stopping in the Genetic Algorithm based on validation performance (if validation sets are added).
-- [ ] Add standard dataset loaders (e.g. MNIST) for easier benchmarking and examples.
+- [x] Add standard dataset loaders (e.g. MNIST) for easier benchmarking and examples.
 - [ ] Provide pre-compiled binaries or packages (e.g. deb, rpm) in releases.

--- a/src/utilities/dataset_loader.cpp
+++ b/src/utilities/dataset_loader.cpp
@@ -1,6 +1,5 @@
 #include "dataset_loader.h"
 #include <fstream>
-#include <iostream>
 
 namespace Utilities {
 namespace Dataset {
@@ -21,29 +20,31 @@ bool MNISTLoader::LoadImages(const std::string& filepath, Matrix::Matrix<float>&
     uint32_t n_rows = 0;
     uint32_t n_cols = 0;
 
-    file.read(reinterpret_cast<char*>(&magic_number), sizeof(magic_number));
+    if (!file.read(reinterpret_cast<char*>(&magic_number), sizeof(magic_number))) return false;
     magic_number = SwapEndian(magic_number);
     if (magic_number != 2051) return false;
 
-    file.read(reinterpret_cast<char*>(&number_of_images), sizeof(number_of_images));
+    if (!file.read(reinterpret_cast<char*>(&number_of_images), sizeof(number_of_images))) return false;
     number_of_images = SwapEndian(number_of_images);
 
-    file.read(reinterpret_cast<char*>(&n_rows), sizeof(n_rows));
+    if (!file.read(reinterpret_cast<char*>(&n_rows), sizeof(n_rows))) return false;
     n_rows = SwapEndian(n_rows);
 
-    file.read(reinterpret_cast<char*>(&n_cols), sizeof(n_cols));
+    if (!file.read(reinterpret_cast<char*>(&n_cols), sizeof(n_cols))) return false;
     n_cols = SwapEndian(n_cols);
 
-    outImages.resize(number_of_images, n_rows * n_cols);
+    const size_t image_size = static_cast<size_t>(n_rows) * static_cast<size_t>(n_cols);
+    Matrix::Matrix<float> images(number_of_images, image_size);
 
     for (size_t i = 0; i < number_of_images; ++i) {
-        for (size_t r = 0; r < n_rows * n_cols; ++r) {
+        for (size_t r = 0; r < image_size; ++r) {
             unsigned char temp = 0;
-            file.read(reinterpret_cast<char*>(&temp), sizeof(temp));
-            outImages[i][r] = static_cast<float>(temp) / 255.0f;
+            if (!file.read(reinterpret_cast<char*>(&temp), sizeof(temp))) return false;
+            images[i][r] = static_cast<float>(temp) / 255.0f;
         }
     }
 
+    outImages = images;
     return true;
 }
 
@@ -54,24 +55,25 @@ bool MNISTLoader::LoadLabels(const std::string& filepath, Matrix::Matrix<float>&
     uint32_t magic_number = 0;
     uint32_t number_of_items = 0;
 
-    file.read(reinterpret_cast<char*>(&magic_number), sizeof(magic_number));
+    if (!file.read(reinterpret_cast<char*>(&magic_number), sizeof(magic_number))) return false;
     magic_number = SwapEndian(magic_number);
     if (magic_number != 2049) return false;
 
-    file.read(reinterpret_cast<char*>(&number_of_items), sizeof(number_of_items));
+    if (!file.read(reinterpret_cast<char*>(&number_of_items), sizeof(number_of_items))) return false;
     number_of_items = SwapEndian(number_of_items);
 
-    outLabels.resize(number_of_items, 10);
-    outLabels.assign(number_of_items, 10, 0.0f);
+    Matrix::Matrix<float> labels;
+    labels.assign(number_of_items, 10, 0.0f);
 
     for (size_t i = 0; i < number_of_items; ++i) {
         unsigned char temp = 0;
-        file.read(reinterpret_cast<char*>(&temp), sizeof(temp));
+        if (!file.read(reinterpret_cast<char*>(&temp), sizeof(temp))) return false;
         if (temp < 10) {
-            outLabels[i][temp] = 1.0f;
+            labels[i][temp] = 1.0f;
         }
     }
 
+    outLabels = labels;
     return true;
 }
 

--- a/src/utilities/dataset_loader.cpp
+++ b/src/utilities/dataset_loader.cpp
@@ -1,0 +1,79 @@
+#include "dataset_loader.h"
+#include <fstream>
+#include <iostream>
+
+namespace Utilities {
+namespace Dataset {
+
+uint32_t MNISTLoader::SwapEndian(uint32_t val) {
+    return ((val << 24) & 0xff000000) |
+           ((val <<  8) & 0x00ff0000) |
+           ((val >>  8) & 0x0000ff00) |
+           ((val >> 24) & 0x000000ff);
+}
+
+bool MNISTLoader::LoadImages(const std::string& filepath, Matrix::Matrix<float>& outImages) {
+    std::ifstream file(filepath, std::ios::binary);
+    if (!file.is_open()) return false;
+
+    uint32_t magic_number = 0;
+    uint32_t number_of_images = 0;
+    uint32_t n_rows = 0;
+    uint32_t n_cols = 0;
+
+    file.read(reinterpret_cast<char*>(&magic_number), sizeof(magic_number));
+    magic_number = SwapEndian(magic_number);
+    if (magic_number != 2051) return false;
+
+    file.read(reinterpret_cast<char*>(&number_of_images), sizeof(number_of_images));
+    number_of_images = SwapEndian(number_of_images);
+
+    file.read(reinterpret_cast<char*>(&n_rows), sizeof(n_rows));
+    n_rows = SwapEndian(n_rows);
+
+    file.read(reinterpret_cast<char*>(&n_cols), sizeof(n_cols));
+    n_cols = SwapEndian(n_cols);
+
+    outImages.resize(number_of_images, n_rows * n_cols);
+
+    for (size_t i = 0; i < number_of_images; ++i) {
+        for (size_t r = 0; r < n_rows * n_cols; ++r) {
+            unsigned char temp = 0;
+            file.read(reinterpret_cast<char*>(&temp), sizeof(temp));
+            outImages[i][r] = static_cast<float>(temp) / 255.0f;
+        }
+    }
+
+    return true;
+}
+
+bool MNISTLoader::LoadLabels(const std::string& filepath, Matrix::Matrix<float>& outLabels) {
+    std::ifstream file(filepath, std::ios::binary);
+    if (!file.is_open()) return false;
+
+    uint32_t magic_number = 0;
+    uint32_t number_of_items = 0;
+
+    file.read(reinterpret_cast<char*>(&magic_number), sizeof(magic_number));
+    magic_number = SwapEndian(magic_number);
+    if (magic_number != 2049) return false;
+
+    file.read(reinterpret_cast<char*>(&number_of_items), sizeof(number_of_items));
+    number_of_items = SwapEndian(number_of_items);
+
+    outLabels.resize(number_of_items, 10);
+    outLabels.assign(number_of_items, 10, 0.0f);
+
+    for (size_t i = 0; i < number_of_items; ++i) {
+        unsigned char temp = 0;
+        file.read(reinterpret_cast<char*>(&temp), sizeof(temp));
+        if (temp < 10) {
+            outLabels[i][temp] = 1.0f;
+        }
+    }
+
+    return true;
+}
+
+} // namespace Dataset
+} // namespace Utilities

--- a/src/utilities/dataset_loader.h
+++ b/src/utilities/dataset_loader.h
@@ -1,0 +1,19 @@
+#pragma once
+#include <string>
+#include <vector>
+#include <cstdint>
+#include "../math/matrix.h"
+
+namespace Utilities {
+namespace Dataset {
+
+class MNISTLoader {
+public:
+    static bool LoadImages(const std::string& filepath, Matrix::Matrix<float>& outImages);
+    static bool LoadLabels(const std::string& filepath, Matrix::Matrix<float>& outLabels);
+private:
+    static uint32_t SwapEndian(uint32_t val);
+};
+
+} // namespace Dataset
+} // namespace Utilities

--- a/src/utilities/dataset_loader.h
+++ b/src/utilities/dataset_loader.h
@@ -1,15 +1,30 @@
 #pragma once
 #include <string>
-#include <vector>
 #include <cstdint>
 #include "../math/matrix.h"
 
 namespace Utilities {
 namespace Dataset {
 
+/**
+ * @brief Loads datasets stored in the MNIST IDX binary file format.
+ */
 class MNISTLoader {
 public:
+    /**
+     * @brief Loads and normalizes MNIST image data from an IDX image file.
+     * @param filepath Path to the IDX image file.
+     * @param outImages Output matrix where each row is one flattened image.
+     * @return True when the file is well-formed and fully read; false otherwise.
+     */
     static bool LoadImages(const std::string& filepath, Matrix::Matrix<float>& outImages);
+
+    /**
+     * @brief Loads MNIST labels from an IDX label file as one-hot rows.
+     * @param filepath Path to the IDX label file.
+     * @param outLabels Output matrix where each row is a one-hot label vector.
+     * @return True when the file is well-formed and fully read; false otherwise.
+     */
     static bool LoadLabels(const std::string& filepath, Matrix::Matrix<float>& outLabels);
 private:
     static uint32_t SwapEndian(uint32_t val);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(runTests
     test_extended_matrix_ops.cpp
     test_timer.cpp
     test_neural_pathfinder.cpp
+    test_dataset_loader.cpp
 )
 
 # Link libraries

--- a/tests/test_dataset_loader.cpp
+++ b/tests/test_dataset_loader.cpp
@@ -1,0 +1,76 @@
+#include <gtest/gtest.h>
+#include "../src/utilities/dataset_loader.h"
+#include "../src/math/matrix.h"
+#include <fstream>
+#include <cstdio>
+
+class MNISTLoaderTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        // Create a dummy MNIST images file
+        std::ofstream imgFile("dummy_images-idx3-ubyte", std::ios::binary);
+        uint32_t magic = 2051;
+        uint32_t num = 2;
+        uint32_t rows = 2;
+        uint32_t cols = 2;
+
+        auto writeSwapped = [&imgFile](uint32_t val) {
+            uint32_t swapped = ((val << 24) & 0xff000000) | ((val << 8) & 0x00ff0000) | ((val >> 8) & 0x0000ff00) | ((val >> 24) & 0x000000ff);
+            imgFile.write(reinterpret_cast<char*>(&swapped), 4);
+        };
+
+        writeSwapped(magic);
+        writeSwapped(num);
+        writeSwapped(rows);
+        writeSwapped(cols);
+
+        unsigned char pixels[8] = {0, 127, 255, 0, 10, 20, 30, 40};
+        imgFile.write(reinterpret_cast<char*>(pixels), 8);
+        imgFile.close();
+
+        // Create a dummy MNIST labels file
+        std::ofstream lblFile("dummy_labels-idx1-ubyte", std::ios::binary);
+        magic = 2049;
+        auto writeSwappedLbl = [&lblFile](uint32_t val) {
+            uint32_t swapped = ((val << 24) & 0xff000000) | ((val << 8) & 0x00ff0000) | ((val >> 8) & 0x0000ff00) | ((val >> 24) & 0x000000ff);
+            lblFile.write(reinterpret_cast<char*>(&swapped), 4);
+        };
+        writeSwappedLbl(magic);
+        writeSwappedLbl(num);
+        unsigned char labels[2] = {5, 0};
+        lblFile.write(reinterpret_cast<char*>(labels), 2);
+        lblFile.close();
+    }
+
+    void TearDown() override {
+        std::remove("dummy_images-idx3-ubyte");
+        std::remove("dummy_labels-idx1-ubyte");
+    }
+};
+
+TEST_F(MNISTLoaderTest, LoadImagesSuccess) {
+    Matrix::Matrix<float> images;
+    bool success = Utilities::Dataset::MNISTLoader::LoadImages("dummy_images-idx3-ubyte", images);
+    EXPECT_TRUE(success);
+    EXPECT_EQ(images.rows(), 2);
+    EXPECT_EQ(images.cols(), 4);
+    EXPECT_NEAR(images[0][1], 127.0f / 255.0f, 1e-4f);
+    EXPECT_NEAR(images[0][2], 1.0f, 1e-4f);
+}
+
+TEST_F(MNISTLoaderTest, LoadLabelsSuccess) {
+    Matrix::Matrix<float> labels;
+    bool success = Utilities::Dataset::MNISTLoader::LoadLabels("dummy_labels-idx1-ubyte", labels);
+    EXPECT_TRUE(success);
+    EXPECT_EQ(labels.rows(), 2);
+    EXPECT_EQ(labels.cols(), 10);
+    EXPECT_EQ(labels[0][5], 1.0f);
+    EXPECT_EQ(labels[0][0], 0.0f);
+    EXPECT_EQ(labels[1][0], 1.0f);
+}
+
+TEST_F(MNISTLoaderTest, FileNotFound) {
+    Matrix::Matrix<float> images;
+    bool success = Utilities::Dataset::MNISTLoader::LoadImages("nonexistent_file", images);
+    EXPECT_FALSE(success);
+}

--- a/tests/test_dataset_loader.cpp
+++ b/tests/test_dataset_loader.cpp
@@ -1,11 +1,20 @@
 #include <gtest/gtest.h>
 #include "../src/utilities/dataset_loader.h"
 #include "../src/math/matrix.h"
+#include <cstdint>
 #include <fstream>
 #include <cstdio>
 
 class MNISTLoaderTest : public ::testing::Test {
 protected:
+    static void WriteBigEndian(std::ofstream& file, uint32_t val) {
+        uint32_t swapped = ((val << 24) & 0xff000000) |
+                           ((val << 8) & 0x00ff0000) |
+                           ((val >> 8) & 0x0000ff00) |
+                           ((val >> 24) & 0x000000ff);
+        file.write(reinterpret_cast<char*>(&swapped), 4);
+    }
+
     void SetUp() override {
         // Create a dummy MNIST images file
         std::ofstream imgFile("dummy_images-idx3-ubyte", std::ios::binary);
@@ -14,15 +23,10 @@ protected:
         uint32_t rows = 2;
         uint32_t cols = 2;
 
-        auto writeSwapped = [&imgFile](uint32_t val) {
-            uint32_t swapped = ((val << 24) & 0xff000000) | ((val << 8) & 0x00ff0000) | ((val >> 8) & 0x0000ff00) | ((val >> 24) & 0x000000ff);
-            imgFile.write(reinterpret_cast<char*>(&swapped), 4);
-        };
-
-        writeSwapped(magic);
-        writeSwapped(num);
-        writeSwapped(rows);
-        writeSwapped(cols);
+        WriteBigEndian(imgFile, magic);
+        WriteBigEndian(imgFile, num);
+        WriteBigEndian(imgFile, rows);
+        WriteBigEndian(imgFile, cols);
 
         unsigned char pixels[8] = {0, 127, 255, 0, 10, 20, 30, 40};
         imgFile.write(reinterpret_cast<char*>(pixels), 8);
@@ -31,12 +35,8 @@ protected:
         // Create a dummy MNIST labels file
         std::ofstream lblFile("dummy_labels-idx1-ubyte", std::ios::binary);
         magic = 2049;
-        auto writeSwappedLbl = [&lblFile](uint32_t val) {
-            uint32_t swapped = ((val << 24) & 0xff000000) | ((val << 8) & 0x00ff0000) | ((val >> 8) & 0x0000ff00) | ((val >> 24) & 0x000000ff);
-            lblFile.write(reinterpret_cast<char*>(&swapped), 4);
-        };
-        writeSwappedLbl(magic);
-        writeSwappedLbl(num);
+        WriteBigEndian(lblFile, magic);
+        WriteBigEndian(lblFile, num);
         unsigned char labels[2] = {5, 0};
         lblFile.write(reinterpret_cast<char*>(labels), 2);
         lblFile.close();
@@ -45,6 +45,8 @@ protected:
     void TearDown() override {
         std::remove("dummy_images-idx3-ubyte");
         std::remove("dummy_labels-idx1-ubyte");
+        std::remove("truncated_images-idx3-ubyte");
+        std::remove("truncated_labels-idx1-ubyte");
     }
 };
 
@@ -73,4 +75,42 @@ TEST_F(MNISTLoaderTest, FileNotFound) {
     Matrix::Matrix<float> images;
     bool success = Utilities::Dataset::MNISTLoader::LoadImages("nonexistent_file", images);
     EXPECT_FALSE(success);
+}
+
+TEST_F(MNISTLoaderTest, LoadImagesRejectsTruncatedPayload) {
+    std::ofstream imgFile("truncated_images-idx3-ubyte", std::ios::binary);
+    WriteBigEndian(imgFile, 2051);
+    WriteBigEndian(imgFile, 1);
+    WriteBigEndian(imgFile, 2);
+    WriteBigEndian(imgFile, 2);
+    unsigned char pixels[3] = {0, 127, 255};
+    imgFile.write(reinterpret_cast<char*>(pixels), 3);
+    imgFile.close();
+
+    Matrix::Matrix<float> images(1, 1);
+    images[0][0] = 42.0f;
+
+    bool success = Utilities::Dataset::MNISTLoader::LoadImages("truncated_images-idx3-ubyte", images);
+    EXPECT_FALSE(success);
+    EXPECT_EQ(images.rows(), 1);
+    EXPECT_EQ(images.cols(), 1);
+    EXPECT_EQ(images[0][0], 42.0f);
+}
+
+TEST_F(MNISTLoaderTest, LoadLabelsRejectsTruncatedPayload) {
+    std::ofstream lblFile("truncated_labels-idx1-ubyte", std::ios::binary);
+    WriteBigEndian(lblFile, 2049);
+    WriteBigEndian(lblFile, 2);
+    unsigned char labels[1] = {3};
+    lblFile.write(reinterpret_cast<char*>(labels), 1);
+    lblFile.close();
+
+    Matrix::Matrix<float> labels_matrix(1, 1);
+    labels_matrix[0][0] = 7.0f;
+
+    bool success = Utilities::Dataset::MNISTLoader::LoadLabels("truncated_labels-idx1-ubyte", labels_matrix);
+    EXPECT_FALSE(success);
+    EXPECT_EQ(labels_matrix.rows(), 1);
+    EXPECT_EQ(labels_matrix.cols(), 1);
+    EXPECT_EQ(labels_matrix[0][0], 7.0f);
 }


### PR DESCRIPTION
This submission adds `MNISTLoader` in `src/utilities/dataset_loader.cpp` / `.h` to parse standard MNIST idx-ubyte binary formats for benchmarking and examples. It addresses the corresponding issue in `TODO.MD` and registers new tests.

---
*PR created automatically by Jules for task [8313858080902502088](https://jules.google.com/task/8313858080902502088) started by @JacobBorden*