### PR TITLE
Update changelog for MNIST loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased] - YYYY-MM-DD
 
 ### Added
+- `MNISTLoader` for standard IDX image and label files, including regression coverage for truncated payloads.
 - `NeuralPathfinder` tests covering empty networks, single-layer networks, multi-layer path selection, and all-zero weights.
 - Unsafe-path regression tests for `Vocabulary` and `TransformerModel` loading.
 - **NeuroNet Model Serialization & Deserialization:**


### PR DESCRIPTION
## Summary
- Document the MNIST IDX loader merged in #111.
- Note the truncated-payload regression coverage added during stewardship.

## Validation
- Docs-only changelog update; no local CMake/CTest run.

PR created by the Neuro-Net-DLL PR Steward automation and intentionally left unmerged for a later stewardship pass.