### PR TITLE
⚡ Bolt: [feature] Enable deb/rpm packaging and GitHub releases

### DIFF
--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -2,15 +2,18 @@ name: Release Packages
 
 on:
   release:
-    types: [created]
+    types: [published]
   workflow_dispatch:
+
+permissions:
+  contents: write
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Install dependencies
       run: sudo apt-get update && sudo apt-get install -y rpm
@@ -18,11 +21,14 @@ jobs:
     - name: Configure CMake
       run: cmake -B build -DCMAKE_BUILD_TYPE=Release
 
-    - name: Build and Package
-      run: cd build && make package
+    - name: Build
+      run: cmake --build build --config Release
+
+    - name: Package
+      run: cmake --build build --config Release --target package
 
     - name: Upload Release Assets
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
         files: |
           build/*.deb

--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -1,0 +1,30 @@
+name: Release Packages
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install dependencies
+      run: sudo apt-get update && sudo apt-get install -y rpm
+
+    - name: Configure CMake
+      run: cmake -B build -DCMAKE_BUILD_TYPE=Release
+
+    - name: Build and Package
+      run: cd build && make package
+
+    - name: Upload Release Assets
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+          build/*.deb
+          build/*.rpm
+          build/*.tar.gz

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,15 +46,11 @@ add_executable(BasicUsageExport examples/basic_usage_export.cpp)
 target_link_libraries(BasicUsageExport PRIVATE neuronet)
 # target_include_directories(BasicUsageExport PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src) # Already covered by global include_directories(src)
 
-set(CPACK_PROJECT_NAME ${PROJECT_NAME})
-set(CPACK_PROJECT_VERSION ${PROJECT_VERSION})
-include(CPack)
-
 # --- INSTALL & PACKAGING ---
 
 include(GNUInstallDirs)
 
-# 1. Install Library
+# Install library
 install(TARGETS neuronet
     EXPORT NeuroNetTargets
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -62,29 +58,25 @@ install(TARGETS neuronet
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 
-# 2. Install Headers
+# Install public headers
 install(DIRECTORY src/
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/neuronet
     FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp"
 )
 
-# 3. Packaging Settings (CPack)
+# Packaging settings must be defined before including CPack.
+set(CPACK_PROJECT_NAME ${PROJECT_NAME})
+set(CPACK_PROJECT_VERSION ${PROJECT_VERSION})
 set(CPACK_PACKAGE_NAME "neuronet")
 set(CPACK_PACKAGE_VENDOR "NeuroNet Contributors")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "C++ Neural Network and Transformer Library")
 set(CPACK_PACKAGE_VERSION_MAJOR "${PROJECT_VERSION_MAJOR}")
 set(CPACK_PACKAGE_VERSION_MINOR "${PROJECT_VERSION_MINOR}")
 set(CPACK_PACKAGE_VERSION_PATCH "${PROJECT_VERSION_PATCH}")
-set(CPACK_PACKAGE_CONTACT "maintainer@example.com") # Required for DEB
+set(CPACK_PACKAGE_CONTACT "maintainer@example.com")
 set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE")
-
-# Set the target packages to build
 set(CPACK_GENERATOR "DEB;RPM;TGZ")
-
-# Debian specifics
 set(CPACK_DEBIAN_PACKAGE_DEPENDS "")
-
-# RPM specifics
 set(CPACK_RPM_PACKAGE_LICENSE "MIT")
 
 include(CPack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,3 +49,42 @@ target_link_libraries(BasicUsageExport PRIVATE neuronet)
 set(CPACK_PROJECT_NAME ${PROJECT_NAME})
 set(CPACK_PROJECT_VERSION ${PROJECT_VERSION})
 include(CPack)
+
+# --- INSTALL & PACKAGING ---
+
+include(GNUInstallDirs)
+
+# 1. Install Library
+install(TARGETS neuronet
+    EXPORT NeuroNetTargets
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
+# 2. Install Headers
+install(DIRECTORY src/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/neuronet
+    FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp"
+)
+
+# 3. Packaging Settings (CPack)
+set(CPACK_PACKAGE_NAME "neuronet")
+set(CPACK_PACKAGE_VENDOR "NeuroNet Contributors")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "C++ Neural Network and Transformer Library")
+set(CPACK_PACKAGE_VERSION_MAJOR "${PROJECT_VERSION_MAJOR}")
+set(CPACK_PACKAGE_VERSION_MINOR "${PROJECT_VERSION_MINOR}")
+set(CPACK_PACKAGE_VERSION_PATCH "${PROJECT_VERSION_PATCH}")
+set(CPACK_PACKAGE_CONTACT "maintainer@example.com") # Required for DEB
+set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE")
+
+# Set the target packages to build
+set(CPACK_GENERATOR "DEB;RPM;TGZ")
+
+# Debian specifics
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "")
+
+# RPM specifics
+set(CPACK_RPM_PACKAGE_LICENSE "MIT")
+
+include(CPack)

--- a/TODO.MD
+++ b/TODO.MD
@@ -11,4 +11,4 @@
 - [x] Add more comprehensive logging and debug modes.
 - [x] Implement early stopping in the Genetic Algorithm based on validation performance (if validation sets are added).
 - [x] Add standard dataset loaders (e.g. MNIST) for easier benchmarking and examples.
-- [ ] Provide pre-compiled binaries or packages (e.g. deb, rpm) in releases.
+- [x] Provide pre-compiled binaries or packages (e.g. deb, rpm) in releases.


### PR DESCRIPTION
This Pull Request adds the capability to generate pre-compiled `.deb`, `.rpm`, and `.tar.gz` binaries using CMake's `CPack` module and automates the process using a GitHub workflow.

**Changes:**
1. **CMake Configuration:** Adds install targets for the library and headers via `GNUInstallDirs`, and defines CPack metadata/generators before the final `include(CPack)` so package settings are captured correctly.
2. **GitHub Actions:** Creates `.github/workflows/release_workflow.yml`, triggered for published GitHub releases and manual dispatches, to compile packages and upload release assets with `softprops/action-gh-release`.
3. **TODO:** Marks the relevant packaging item as checked in `TODO.MD`.

**Steward validation:** Rebased onto current `master`; local Release CMake configure/build and CTest passed, and `cpack -G TGZ` generated a package. DEB/RPM packaging remains covered by the release workflow's Ubuntu package tooling.

---
*PR created automatically by Jules for task [4222166900764375535](https://jules.google.com/task/4222166900764375535) started by @JacobBorden*