### PR TITLE
Update changelog for release packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased] - YYYY-MM-DD
 
 ### Added
+- Release packaging support for DEB, RPM, and TGZ artifacts through CPack and a published-release GitHub Actions workflow.
 - Thread-safe `Logger` utility with configurable debug/info/warning/error levels, output redirection, and unit coverage.
 - `MNISTLoader` for standard IDX image and label files, including regression coverage for truncated payloads.
 - `NeuralPathfinder` tests covering empty networks, single-layer networks, multi-layer path selection, and all-zero weights.


### PR DESCRIPTION
Docs-only follow-up for merged #125.

Updates the unreleased changelog to record the new CPack DEB/RPM/TGZ packaging support and published-release GitHub Actions workflow.

This PR is intentionally left open for a later steward run rather than being merged in the same automation pass.