### PR TITLE
Implement Transformer Decoder and Encoder-Decoder Model

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,8 @@ add_library(neuronet STATIC
     src/transformer/multi_head_attention.cpp
     src/transformer/positional_encoding.cpp
     src/transformer/transformer_encoder_layer.cpp
+    src/transformer/transformer_decoder_layer.cpp
+    src/transformer/transformer_encoder_decoder_model.cpp
     src/transformer/transformer_ffn.cpp
     src/transformer/transformer_model.cpp
     src/math/extended_matrix_ops.cpp

--- a/TODO.MD
+++ b/TODO.MD
@@ -7,7 +7,7 @@
 - [x] Optimize memory allocation during Matrix operations (e.g. avoid copies).
 - [x] Implement better OpenMP parallelization in Neural Network forward pass, not just Matrix multiplication.
 - [x] Create a Python binding / API for the library (e.g., using pybind11).
-- [ ] Expand the Transformer module to include Decoder layers and full Encoder-Decoder models.
+- [x] Expand the Transformer module to include Decoder layers and full Encoder-Decoder models.
 - [x] Add more comprehensive logging and debug modes.
 - [x] Implement early stopping in the Genetic Algorithm based on validation performance (if validation sets are added).
 - [x] Add standard dataset loaders (e.g. MNIST) for easier benchmarking and examples.

--- a/src/transformer/transformer_decoder_layer.cpp
+++ b/src/transformer/transformer_decoder_layer.cpp
@@ -1,0 +1,70 @@
+#include "transformer_decoder_layer.h"
+#include <iostream>
+
+namespace NeuroNet {
+namespace Transformer {
+
+TransformerDecoderLayer::TransformerDecoderLayer(
+    int d_model,
+    int num_heads,
+    int d_ff,
+    float attention_dropout_rate,
+    float ffn_dropout_rate,
+    float layer_norm_epsilon)
+    : d_model_(d_model),
+      layer_norm_epsilon_(layer_norm_epsilon),
+      self_attention_(num_heads, d_model, attention_dropout_rate),
+      cross_attention_(num_heads, d_model, attention_dropout_rate),
+      transformer_ffn_(d_model, d_ff, ffn_dropout_rate) {
+
+    if (d_model <= 0) {
+        throw std::invalid_argument("d_model must be positive for TransformerDecoderLayer.");
+    }
+}
+
+void TransformerDecoderLayer::initialize_weights() {
+    // sub-modules self initialize
+}
+
+Matrix::Matrix<float> TransformerDecoderLayer::forward(
+    const Matrix::Matrix<float>& input,
+    const Matrix::Matrix<float>& encoder_output,
+    const Matrix::Matrix<float>& self_attention_mask,
+    const Matrix::Matrix<float>& cross_attention_mask) {
+
+    if (input.cols() != static_cast<size_t>(d_model_)) {
+        throw std::invalid_argument("Input matrix column count (" + std::to_string(input.cols()) +
+                                    ") must match TransformerDecoderLayer d_model (" + std::to_string(d_model_) + ").");
+    }
+    if (encoder_output.cols() != static_cast<size_t>(d_model_)) {
+        throw std::invalid_argument("Encoder output matrix column count (" + std::to_string(encoder_output.cols()) +
+                                    ") must match TransformerDecoderLayer d_model (" + std::to_string(d_model_) + ").");
+    }
+    if (input.rows() == 0) {
+        return Matrix::Matrix<float>(0, d_model_);
+    }
+
+    // 1. Masked Multi-Head Self-Attention Block
+    Matrix::Matrix<float> normed_input1 = MathUtils::layer_norm(input, layer_norm_epsilon_);
+    Matrix::Matrix<float> self_attention_output = self_attention_.forward(
+        normed_input1, normed_input1, normed_input1, self_attention_mask
+    );
+    Matrix::Matrix<float> residual_output1 = input + self_attention_output;
+
+    // 2. Multi-Head Cross-Attention Block
+    Matrix::Matrix<float> normed_input2 = MathUtils::layer_norm(residual_output1, layer_norm_epsilon_);
+    Matrix::Matrix<float> cross_attention_output = cross_attention_.forward(
+        normed_input2, encoder_output, encoder_output, cross_attention_mask
+    );
+    Matrix::Matrix<float> residual_output2 = residual_output1 + cross_attention_output;
+
+    // 3. Feed-Forward Network Block
+    Matrix::Matrix<float> normed_input3 = MathUtils::layer_norm(residual_output2, layer_norm_epsilon_);
+    Matrix::Matrix<float> ffn_output = transformer_ffn_.forward(normed_input3);
+    Matrix::Matrix<float> final_output = residual_output2 + ffn_output;
+
+    return final_output;
+}
+
+} // namespace Transformer
+} // namespace NeuroNet

--- a/src/transformer/transformer_decoder_layer.h
+++ b/src/transformer/transformer_decoder_layer.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include "multi_head_attention.h"
+#include "transformer_ffn.h"
+#include "../math/matrix.h"
+#include "../math/extended_matrix_ops.h" // For MathUtils::layer_norm
+#include <stdexcept>
+
+namespace NeuroNet {
+namespace Transformer {
+
+class TransformerDecoderLayer {
+public:
+    /**
+     * @brief Constructor for TransformerDecoderLayer.
+     * @param d_model Dimensionality of the input and output.
+     * @param num_heads Number of attention heads for MultiHeadAttention.
+     * @param d_ff Dimensionality of the inner feed-forward layer in TransformerFFN.
+     * @param attention_dropout_rate Dropout rate for multi-head attention (currently unused).
+     * @param ffn_dropout_rate Dropout rate for FFN (currently unused).
+     * @param layer_norm_epsilon Epsilon value for Layer Normalization.
+     */
+    TransformerDecoderLayer(
+        int d_model,
+        int num_heads,
+        int d_ff,
+        float attention_dropout_rate = 0.0f,
+        float ffn_dropout_rate = 0.0f,
+        float layer_norm_epsilon = 1e-5f
+    );
+
+    /**
+     * @brief Initializes weights for sub-modules.
+     */
+    void initialize_weights();
+
+    /**
+     * @brief Performs the forward pass for the Transformer Decoder Layer.
+     * @param input Input matrix, shape (tgt_seq_len, d_model).
+     * @param encoder_output Encoder output matrix, shape (src_seq_len, d_model).
+     * @param self_attention_mask Optional mask for self-attention, shape (tgt_seq_len, tgt_seq_len).
+     * @param cross_attention_mask Optional mask for cross-attention, shape (tgt_seq_len, src_seq_len).
+     * @return Matrix::Matrix<float> The output matrix, shape (tgt_seq_len, d_model).
+     * @throws std::invalid_argument if input dimensions are incorrect.
+     */
+    Matrix::Matrix<float> forward(
+        const Matrix::Matrix<float>& input,
+        const Matrix::Matrix<float>& encoder_output,
+        const Matrix::Matrix<float>& self_attention_mask = Matrix::Matrix<float>(0,0),
+        const Matrix::Matrix<float>& cross_attention_mask = Matrix::Matrix<float>(0,0)
+    );
+
+    MultiHeadAttention& get_self_attention_module() { return self_attention_; }
+    const MultiHeadAttention& get_self_attention_module() const { return self_attention_; }
+
+    MultiHeadAttention& get_cross_attention_module() { return cross_attention_; }
+    const MultiHeadAttention& get_cross_attention_module() const { return cross_attention_; }
+
+    TransformerFFN& get_ffn_module() { return transformer_ffn_; }
+    const TransformerFFN& get_ffn_module() const { return transformer_ffn_; }
+
+    int get_d_model() const { return d_model_; }
+
+private:
+    int d_model_;
+    float layer_norm_epsilon_;
+
+    MultiHeadAttention self_attention_;
+    MultiHeadAttention cross_attention_;
+    TransformerFFN transformer_ffn_;
+};
+
+} // namespace Transformer
+} // namespace NeuroNet

--- a/src/transformer/transformer_encoder_decoder_model.cpp
+++ b/src/transformer/transformer_encoder_decoder_model.cpp
@@ -71,15 +71,33 @@ Matrix::Matrix<float> TransformerEncoderDecoderModel::forward(
     Matrix::Matrix<float> tgt_embeddings = tgt_embedding_layer_.forward(tgt_input_token_ids);
     Matrix::Matrix<float> tgt_pos_embeddings = positional_encoding_.forward(tgt_embeddings);
     Matrix::Matrix<float> decoder_output = tgt_pos_embeddings;
+    Matrix::Matrix<float> effective_tgt_self_attention_mask = tgt_self_attention_mask;
+    if (effective_tgt_self_attention_mask.rows() == 0 || effective_tgt_self_attention_mask.cols() == 0) {
+        effective_tgt_self_attention_mask = create_causal_mask(tgt_pos_embeddings.rows());
+    }
 
     for (int i = 0; i < num_decoder_layers_; ++i) {
         decoder_output = decoder_layers_[i].forward(
-            decoder_output, encoder_output, tgt_self_attention_mask, tgt_cross_attention_mask
+            decoder_output, encoder_output, effective_tgt_self_attention_mask, tgt_cross_attention_mask
         );
     }
 
     Matrix::Matrix<float> final_norm_output = MathUtils::layer_norm(decoder_output, layer_norm_epsilon_);
     return final_norm_output;
+}
+
+Matrix::Matrix<float> TransformerEncoderDecoderModel::create_causal_mask(size_t sequence_length) const {
+    Matrix::Matrix<float> mask(sequence_length, sequence_length);
+    mask.assign(0.0f);
+
+    constexpr float masked_attention_score = -1.0e9f;
+    for (size_t row = 0; row < sequence_length; ++row) {
+        for (size_t col = row + 1; col < sequence_length; ++col) {
+            mask[row][col] = masked_attention_score;
+        }
+    }
+
+    return mask;
 }
 
 } // namespace Transformer

--- a/src/transformer/transformer_encoder_decoder_model.cpp
+++ b/src/transformer/transformer_encoder_decoder_model.cpp
@@ -1,0 +1,86 @@
+#include "transformer_encoder_decoder_model.h"
+
+namespace NeuroNet {
+namespace Transformer {
+
+TransformerEncoderDecoderModel::TransformerEncoderDecoderModel(
+    int src_vocab_size,
+    int tgt_vocab_size,
+    int max_seq_len,
+    int d_model,
+    int num_encoder_layers,
+    int num_decoder_layers,
+    int num_heads,
+    int d_ff,
+    float dropout_rate,
+    float layer_norm_epsilon)
+    : src_vocab_size_(src_vocab_size),
+      tgt_vocab_size_(tgt_vocab_size),
+      max_seq_len_(max_seq_len),
+      d_model_(d_model),
+      num_encoder_layers_(num_encoder_layers),
+      num_decoder_layers_(num_decoder_layers),
+      num_heads_(num_heads),
+      d_ff_(d_ff),
+      dropout_rate_(dropout_rate),
+      layer_norm_epsilon_(layer_norm_epsilon),
+      src_embedding_layer_(src_vocab_size, d_model),
+      tgt_embedding_layer_(tgt_vocab_size, d_model),
+      positional_encoding_(max_seq_len, d_model) {
+
+    if (d_model <= 0 || num_encoder_layers <= 0 || num_decoder_layers <= 0) {
+        throw std::invalid_argument("Invalid hyperparameters for TransformerEncoderDecoderModel.");
+    }
+
+    encoder_layers_.reserve(num_encoder_layers_);
+    for (int i = 0; i < num_encoder_layers_; ++i) {
+        encoder_layers_.emplace_back(
+            d_model_, num_heads_, d_ff_, dropout_rate_, dropout_rate_, layer_norm_epsilon_
+        );
+    }
+
+    decoder_layers_.reserve(num_decoder_layers_);
+    for (int i = 0; i < num_decoder_layers_; ++i) {
+        decoder_layers_.emplace_back(
+            d_model_, num_heads_, d_ff_, dropout_rate_, dropout_rate_, layer_norm_epsilon_
+        );
+    }
+}
+
+Matrix::Matrix<float> TransformerEncoderDecoderModel::forward(
+    const Matrix::Matrix<float>& src_input_token_ids,
+    const Matrix::Matrix<float>& tgt_input_token_ids,
+    const Matrix::Matrix<float>& src_attention_mask,
+    const Matrix::Matrix<float>& tgt_self_attention_mask,
+    const Matrix::Matrix<float>& tgt_cross_attention_mask) {
+
+    if (src_input_token_ids.rows() != 1 || tgt_input_token_ids.rows() != 1) {
+        throw std::invalid_argument("Input token IDs must have exactly 1 row.");
+    }
+
+    // Encoder
+    Matrix::Matrix<float> src_embeddings = src_embedding_layer_.forward(src_input_token_ids);
+    Matrix::Matrix<float> src_pos_embeddings = positional_encoding_.forward(src_embeddings);
+    Matrix::Matrix<float> encoder_output = src_pos_embeddings;
+
+    for (int i = 0; i < num_encoder_layers_; ++i) {
+        encoder_output = encoder_layers_[i].forward(encoder_output, src_attention_mask);
+    }
+
+    // Decoder
+    Matrix::Matrix<float> tgt_embeddings = tgt_embedding_layer_.forward(tgt_input_token_ids);
+    Matrix::Matrix<float> tgt_pos_embeddings = positional_encoding_.forward(tgt_embeddings);
+    Matrix::Matrix<float> decoder_output = tgt_pos_embeddings;
+
+    for (int i = 0; i < num_decoder_layers_; ++i) {
+        decoder_output = decoder_layers_[i].forward(
+            decoder_output, encoder_output, tgt_self_attention_mask, tgt_cross_attention_mask
+        );
+    }
+
+    Matrix::Matrix<float> final_norm_output = MathUtils::layer_norm(decoder_output, layer_norm_epsilon_);
+    return final_norm_output;
+}
+
+} // namespace Transformer
+} // namespace NeuroNet

--- a/src/transformer/transformer_encoder_decoder_model.h
+++ b/src/transformer/transformer_encoder_decoder_model.h
@@ -1,0 +1,94 @@
+#pragma once
+
+#include "embedding.h"
+#include "positional_encoding.h"
+#include "transformer_encoder_layer.h"
+#include "transformer_decoder_layer.h"
+#include "../math/matrix.h"
+#include "../math/extended_matrix_ops.h"
+#include <vector>
+#include <stdexcept>
+
+namespace NeuroNet {
+namespace Transformer {
+
+class TransformerEncoderDecoderModel {
+public:
+    /**
+     * @brief Constructor for the full Transformer Encoder-Decoder model.
+     * @param src_vocab_size Size of the vocabulary for the encoder embedding layer.
+     * @param tgt_vocab_size Size of the vocabulary for the decoder embedding layer.
+     * @param max_seq_len Maximum sequence length for positional encoding.
+     * @param d_model Dimensionality of embeddings and model layers.
+     * @param num_encoder_layers Number of TransformerEncoderLayer to stack.
+     * @param num_decoder_layers Number of TransformerDecoderLayer to stack.
+     * @param num_heads Number of attention heads in each layer.
+     * @param d_ff Dimensionality of the feed-forward network within each layer.
+     * @param dropout_rate General dropout rate (placeholder).
+     * @param layer_norm_epsilon Epsilon for LayerNormalization.
+     */
+    TransformerEncoderDecoderModel(
+        int src_vocab_size,
+        int tgt_vocab_size,
+        int max_seq_len,
+        int d_model,
+        int num_encoder_layers,
+        int num_decoder_layers,
+        int num_heads,
+        int d_ff,
+        float dropout_rate = 0.0f,
+        float layer_norm_epsilon = 1e-5f
+    );
+
+    /**
+     * @brief Performs the forward pass of the encoder-decoder model.
+     * @param src_input_token_ids Matrix of source token IDs, shape (1, src_seq_len).
+     * @param tgt_input_token_ids Matrix of target token IDs, shape (1, tgt_seq_len).
+     * @param src_attention_mask Optional mask for encoder self-attention.
+     * @param tgt_self_attention_mask Optional mask for decoder self-attention.
+     * @param tgt_cross_attention_mask Optional mask for decoder cross-attention.
+     * @return Matrix::Matrix<float> Output matrix from the final decoder layer,
+     *                               after final layer normalization. Shape (tgt_seq_len, d_model).
+     */
+    Matrix::Matrix<float> forward(
+        const Matrix::Matrix<float>& src_input_token_ids,
+        const Matrix::Matrix<float>& tgt_input_token_ids,
+        const Matrix::Matrix<float>& src_attention_mask = Matrix::Matrix<float>(0,0),
+        const Matrix::Matrix<float>& tgt_self_attention_mask = Matrix::Matrix<float>(0,0),
+        const Matrix::Matrix<float>& tgt_cross_attention_mask = Matrix::Matrix<float>(0,0)
+    );
+
+    // --- Accessors ---
+    EmbeddingLayer& get_src_embedding_layer() { return src_embedding_layer_; }
+    EmbeddingLayer& get_tgt_embedding_layer() { return tgt_embedding_layer_; }
+    PositionalEncoding& get_positional_encoding_module() { return positional_encoding_; }
+    std::vector<TransformerEncoderLayer>& get_encoder_layers() { return encoder_layers_; }
+    std::vector<TransformerDecoderLayer>& get_decoder_layers() { return decoder_layers_; }
+
+    int get_src_vocab_size() const { return src_vocab_size_; }
+    int get_tgt_vocab_size() const { return tgt_vocab_size_; }
+    int get_d_model() const { return d_model_; }
+    int get_num_encoder_layers() const { return num_encoder_layers_; }
+    int get_num_decoder_layers() const { return num_decoder_layers_; }
+
+private:
+    int src_vocab_size_;
+    int tgt_vocab_size_;
+    int max_seq_len_;
+    int d_model_;
+    int num_encoder_layers_;
+    int num_decoder_layers_;
+    int num_heads_;
+    int d_ff_;
+    float dropout_rate_;
+    float layer_norm_epsilon_;
+
+    EmbeddingLayer src_embedding_layer_;
+    EmbeddingLayer tgt_embedding_layer_;
+    PositionalEncoding positional_encoding_;
+    std::vector<TransformerEncoderLayer> encoder_layers_;
+    std::vector<TransformerDecoderLayer> decoder_layers_;
+};
+
+} // namespace Transformer
+} // namespace NeuroNet

--- a/src/transformer/transformer_encoder_decoder_model.h
+++ b/src/transformer/transformer_encoder_decoder_model.h
@@ -6,6 +6,7 @@
 #include "transformer_decoder_layer.h"
 #include "../math/matrix.h"
 #include "../math/extended_matrix_ops.h"
+#include <cstddef>
 #include <vector>
 #include <stdexcept>
 
@@ -45,7 +46,7 @@ public:
      * @param src_input_token_ids Matrix of source token IDs, shape (1, src_seq_len).
      * @param tgt_input_token_ids Matrix of target token IDs, shape (1, tgt_seq_len).
      * @param src_attention_mask Optional mask for encoder self-attention.
-     * @param tgt_self_attention_mask Optional mask for decoder self-attention.
+     * @param tgt_self_attention_mask Optional mask for decoder self-attention. If omitted, a causal mask is generated.
      * @param tgt_cross_attention_mask Optional mask for decoder cross-attention.
      * @return Matrix::Matrix<float> Output matrix from the final decoder layer,
      *                               after final layer normalization. Shape (tgt_seq_len, d_model).
@@ -88,6 +89,13 @@ private:
     PositionalEncoding positional_encoding_;
     std::vector<TransformerEncoderLayer> encoder_layers_;
     std::vector<TransformerDecoderLayer> decoder_layers_;
+
+    /**
+     * @brief Creates an additive causal mask for decoder self-attention.
+     * @param sequence_length Target sequence length.
+     * @return Matrix with 0.0f for visible positions and a large negative value for future positions.
+     */
+    Matrix::Matrix<float> create_causal_mask(size_t sequence_length) const;
 };
 
 } // namespace Transformer

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(runTests
     test_json.cpp
     test_vocabulary.cpp
     test_transformer_model.cpp
+    test_transformer_encoder_decoder.cpp
     test_gaussian_distribution.cpp
     test_least_squares.cpp
     test_naive_bayes.cpp

--- a/tests/test_transformer_encoder_decoder.cpp
+++ b/tests/test_transformer_encoder_decoder.cpp
@@ -1,0 +1,80 @@
+#include <gtest/gtest.h>
+#include "../src/transformer/transformer_encoder_decoder_model.h"
+
+using namespace NeuroNet::Transformer;
+
+class TransformerEncoderDecoderTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        // Initialize basic parameters for tests
+    }
+};
+
+TEST_F(TransformerEncoderDecoderTest, Initialization) {
+    int src_vocab_size = 100;
+    int tgt_vocab_size = 150;
+    int max_seq_len = 50;
+    int d_model = 64;
+    int num_encoder_layers = 2;
+    int num_decoder_layers = 2;
+    int num_heads = 8;
+    int d_ff = 128;
+
+    EXPECT_NO_THROW({
+        TransformerEncoderDecoderModel model(
+            src_vocab_size, tgt_vocab_size, max_seq_len, d_model,
+            num_encoder_layers, num_decoder_layers, num_heads, d_ff
+        );
+    });
+}
+
+TEST_F(TransformerEncoderDecoderTest, ForwardPassBasic) {
+    int src_vocab_size = 100;
+    int tgt_vocab_size = 150;
+    int max_seq_len = 50;
+    int d_model = 64;
+    int num_encoder_layers = 1;
+    int num_decoder_layers = 1;
+    int num_heads = 4;
+    int d_ff = 128;
+
+    TransformerEncoderDecoderModel model(
+        src_vocab_size, tgt_vocab_size, max_seq_len, d_model,
+        num_encoder_layers, num_decoder_layers, num_heads, d_ff
+    );
+
+    int src_seq_len = 5;
+    int tgt_seq_len = 6;
+    Matrix::Matrix<float> src_input_ids(1, src_seq_len);
+    Matrix::Matrix<float> tgt_input_ids(1, tgt_seq_len);
+    for (int i = 0; i < src_seq_len; ++i) src_input_ids[0][i] = i;
+    for (int i = 0; i < tgt_seq_len; ++i) tgt_input_ids[0][i] = i + 10;
+
+    Matrix::Matrix<float> output;
+    EXPECT_NO_THROW({
+        output = model.forward(src_input_ids, tgt_input_ids);
+    });
+
+    EXPECT_EQ(output.rows(), static_cast<size_t>(tgt_seq_len));
+    EXPECT_EQ(output.cols(), static_cast<size_t>(d_model));
+}
+
+TEST_F(TransformerEncoderDecoderTest, InvalidInputHandling) {
+    int src_vocab_size = 100;
+    int tgt_vocab_size = 150;
+    int max_seq_len = 50;
+    int d_model = 64;
+    int num_encoder_layers = 1;
+    int num_decoder_layers = 1;
+    int num_heads = 4;
+    int d_ff = 128;
+
+    TransformerEncoderDecoderModel model(
+        src_vocab_size, tgt_vocab_size, max_seq_len, d_model,
+        num_encoder_layers, num_decoder_layers, num_heads, d_ff
+    );
+
+    Matrix::Matrix<float> invalid_src_input(2, 5); // Should be 1 row
+    Matrix::Matrix<float> tgt_input(1, 6);
+    EXPECT_THROW(model.forward(invalid_src_input, tgt_input), std::invalid_argument);
+}

--- a/tests/test_transformer_encoder_decoder.cpp
+++ b/tests/test_transformer_encoder_decoder.cpp
@@ -59,6 +59,36 @@ TEST_F(TransformerEncoderDecoderTest, ForwardPassBasic) {
     EXPECT_EQ(output.cols(), static_cast<size_t>(d_model));
 }
 
+TEST_F(TransformerEncoderDecoderTest, DefaultDecoderMaskPreventsFutureTokenLeakage) {
+    TransformerEncoderDecoderModel model(
+        100, 100, 10, 16,
+        1, 1, 4, 32
+    );
+
+    Matrix::Matrix<float> src_input_ids(1, 4);
+    for (int i = 0; i < 4; ++i) {
+        src_input_ids[0][i] = i + 1;
+    }
+
+    Matrix::Matrix<float> tgt_input_ids_a(1, 3);
+    Matrix::Matrix<float> tgt_input_ids_b(1, 3);
+    tgt_input_ids_a[0][0] = 10;
+    tgt_input_ids_a[0][1] = 11;
+    tgt_input_ids_a[0][2] = 12;
+    tgt_input_ids_b[0][0] = 10;
+    tgt_input_ids_b[0][1] = 11;
+    tgt_input_ids_b[0][2] = 35;
+
+    Matrix::Matrix<float> output_a = model.forward(src_input_ids, tgt_input_ids_a);
+    Matrix::Matrix<float> output_b = model.forward(src_input_ids, tgt_input_ids_b);
+
+    for (size_t row = 0; row < 2; ++row) {
+        for (size_t col = 0; col < output_a.cols(); ++col) {
+            EXPECT_NEAR(output_a[row][col], output_b[row][col], 1e-5f);
+        }
+    }
+}
+
 TEST_F(TransformerEncoderDecoderTest, InvalidInputHandling) {
     int src_vocab_size = 100;
     int tgt_vocab_size = 150;


### PR DESCRIPTION
This PR adds the missing Decoder component to the Transformer module. It implements `TransformerDecoderLayer` with masked self-attention, cross-attention, and an FFN. It also introduces `TransformerEncoderDecoderModel` to tie the entire sequence-to-sequence structure together. The build files and TODO lists were updated, and tests for the new architecture were written to verify forward pass operation.

PR steward update for 2026-06-30:
- Rebased onto current `master` after #136 merged.
- Added default causal decoder self-attention mask generation when `forward(src, tgt)` omits `tgt_self_attention_mask`.
- Added regression coverage that future target-token changes do not affect earlier decoder outputs under the default mask.
- Local validation passed with Python 3.11 pinned: `cmake -B build -DCMAKE_BUILD_TYPE=Release -DPython3_EXECUTABLE=/bin/python3.11 -DPYTHON_EXECUTABLE=/bin/python3.11`, `cmake --build build --config Release`, and `ctest --test-dir build -C Release --output-on-failure` (178/178).

---
*PR created automatically by Jules for task [9930568919225893395](https://jules.google.com/task/9930568919225893395) started by @JacobBorden*