### PR TITLE
Update changelog for transformer decoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Release packaging support for DEB, RPM, and TGZ artifacts through CPack and a published-release GitHub Actions workflow.
 - `pyneuronet` Python bindings for core matrix and neural-network APIs, including CTest-covered binding smoke tests and install packaging for the extension module.
+- Transformer decoder layers and a full encoder-decoder model, including default causal decoder self-attention masking and regression coverage for future-token leakage.
 - Thread-safe `Logger` utility with configurable debug/info/warning/error levels, output redirection, and unit coverage.
 - `MNISTLoader` for standard IDX image and label files, including regression coverage for truncated payloads.
 - `NeuralPathfinder` tests covering empty networks, single-layer networks, multi-layer path selection, and all-zero weights.


### PR DESCRIPTION
## Summary
- Add an Unreleased changelog entry for the merged Transformer decoder and encoder-decoder model work from #137.

## Validation
- Docs-only change; no local CMake/CTest run.

Steward follow-up: this PR is intentionally left open for a later steward run to review and merge after GitHub checks pass.