### PR TITLE
Add support for Recurrent Neural Networks (RNNs)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 add_library(neuronet STATIC 
     src/neural_network/neuronet.cpp
+    src/neural_network/rnn_layer.cpp
     src/optimization/genetic_algorithm.cpp
     src/optimization/neural_pathfinder.cpp
     src/utilities/json/json.cpp

--- a/TODO.MD
+++ b/TODO.MD
@@ -3,7 +3,8 @@
 - [x] Add more activation functions (e.g., Sigmoid, Tanh, Swish).
 - [ ] Implement Backpropagation algorithm as an alternative to Genetic Algorithm for training.
 - [ ] Add support for Convolutional Neural Networks (CNNs).
-- [x] Add support for Recurrent Neural Networks (RNNs) / LSTMs.
+- [x] Add basic Recurrent Neural Network (RNN) layer support.
+- [ ] Add support for Long Short-Term Memory (LSTM) recurrent layers.
 - [x] Optimize memory allocation during Matrix operations (e.g. avoid copies).
 - [x] Implement better OpenMP parallelization in Neural Network forward pass, not just Matrix multiplication.
 - [x] Create a Python binding / API for the library (e.g., using pybind11).

--- a/TODO.MD
+++ b/TODO.MD
@@ -3,7 +3,7 @@
 - [x] Add more activation functions (e.g., Sigmoid, Tanh, Swish).
 - [ ] Implement Backpropagation algorithm as an alternative to Genetic Algorithm for training.
 - [ ] Add support for Convolutional Neural Networks (CNNs).
-- [ ] Add support for Recurrent Neural Networks (RNNs) / LSTMs.
+- [x] Add support for Recurrent Neural Networks (RNNs) / LSTMs.
 - [x] Optimize memory allocation during Matrix operations (e.g. avoid copies).
 - [x] Implement better OpenMP parallelization in Neural Network forward pass, not just Matrix multiplication.
 - [x] Create a Python binding / API for the library (e.g., using pybind11).

--- a/src/neural_network/rnn_layer.cpp
+++ b/src/neural_network/rnn_layer.cpp
@@ -1,11 +1,14 @@
 #include "rnn_layer.h"
 #include <cmath> // For std::tanh
-#include <random>
+#include <stdexcept>
 
 namespace NeuroNet {
 
 RNNLayer::RNNLayer(int input_size, int hidden_size)
     : input_size_(input_size), hidden_size_(hidden_size) {
+    if (input_size_ <= 0 || hidden_size_ <= 0) {
+        throw std::invalid_argument("RNNLayer dimensions must be positive.");
+    }
 
     // Initialize weights and biases
     W_xh.resize(input_size_, hidden_size_);
@@ -23,7 +26,7 @@ RNNLayer::RNNLayer(int input_size, int hidden_size)
 }
 
 Matrix::Matrix<float> RNNLayer::Forward(const Matrix::Matrix<float>& input) {
-    if (input.cols() != input_size_) {
+    if (input.rows() != 1 || input.cols() != static_cast<size_t>(input_size_)) {
         throw std::invalid_argument("Input size mismatch in RNNLayer.");
     }
 

--- a/src/neural_network/rnn_layer.cpp
+++ b/src/neural_network/rnn_layer.cpp
@@ -1,0 +1,48 @@
+#include "rnn_layer.h"
+#include <cmath> // For std::tanh
+#include <random>
+
+namespace NeuroNet {
+
+RNNLayer::RNNLayer(int input_size, int hidden_size)
+    : input_size_(input_size), hidden_size_(hidden_size) {
+
+    // Initialize weights and biases
+    W_xh.resize(input_size_, hidden_size_);
+    W_xh.Randomize();
+
+    W_hh.resize(hidden_size_, hidden_size_);
+    W_hh.Randomize();
+
+    b_h.resize(1, hidden_size_);
+    b_h.assign(0.0f); // Initialize bias to 0
+
+    // Initialize hidden state
+    h_prev.resize(1, hidden_size_);
+    h_prev.assign(0.0f);
+}
+
+Matrix::Matrix<float> RNNLayer::Forward(const Matrix::Matrix<float>& input) {
+    if (input.cols() != input_size_) {
+        throw std::invalid_argument("Input size mismatch in RNNLayer.");
+    }
+
+    // h_t = tanh(W_xh * x_t + W_hh * h_{t-1} + b_h)
+    Matrix::Matrix<float> h_t = (input * W_xh) + (h_prev * W_hh) + b_h;
+
+    // Apply tanh activation manually (since it's a basic implementation)
+    for (size_t r = 0; r < h_t.rows(); ++r) {
+        for (size_t c = 0; c < h_t.cols(); ++c) {
+            h_t[r][c] = std::tanh(h_t[r][c]);
+        }
+    }
+
+    h_prev = h_t; // Update hidden state
+    return h_t;
+}
+
+void RNNLayer::ResetState() {
+    h_prev.assign(0.0f);
+}
+
+} // namespace NeuroNet

--- a/src/neural_network/rnn_layer.h
+++ b/src/neural_network/rnn_layer.h
@@ -1,0 +1,33 @@
+#pragma once
+#include "../math/matrix.h"
+
+namespace NeuroNet {
+
+class RNNLayer {
+public:
+    RNNLayer(int input_size, int hidden_size);
+
+    // Forward pass for a single time step
+    Matrix::Matrix<float> Forward(const Matrix::Matrix<float>& input);
+
+    // Reset the hidden state (e.g., at the start of a new sequence)
+    void ResetState();
+
+    // Getters for weights and biases
+    Matrix::Matrix<float>& GetW_xh() { return W_xh; }
+    Matrix::Matrix<float>& GetW_hh() { return W_hh; }
+    Matrix::Matrix<float>& Getb_h() { return b_h; }
+    Matrix::Matrix<float> GetHiddenState() const { return h_prev; }
+
+private:
+    int input_size_;
+    int hidden_size_;
+
+    Matrix::Matrix<float> W_xh; // Input to hidden weights
+    Matrix::Matrix<float> W_hh; // Hidden to hidden weights
+    Matrix::Matrix<float> b_h;  // Hidden bias
+
+    Matrix::Matrix<float> h_prev; // Previous hidden state
+};
+
+} // namespace NeuroNet

--- a/src/neural_network/rnn_layer.h
+++ b/src/neural_network/rnn_layer.h
@@ -3,20 +3,46 @@
 
 namespace NeuroNet {
 
+/**
+ * @brief Basic recurrent neural-network layer with tanh hidden-state updates.
+ *
+ * RNNLayer processes one time step at a time. Each forward pass combines the
+ * input with the previous hidden state and stores the resulting hidden state
+ * for the next call.
+ */
 class RNNLayer {
 public:
+    /**
+     * @brief Constructs a recurrent layer.
+     * @param input_size Number of input features per time step. Must be positive.
+     * @param hidden_size Number of hidden units. Must be positive.
+     * @throws std::invalid_argument if either dimension is non-positive.
+     */
     RNNLayer(int input_size, int hidden_size);
 
-    // Forward pass for a single time step
+    /**
+     * @brief Runs the layer for a single time step.
+     * @param input A 1 x input_size matrix containing the time-step input.
+     * @return The updated 1 x hidden_size hidden state.
+     * @throws std::invalid_argument if input dimensions do not match the layer.
+     */
     Matrix::Matrix<float> Forward(const Matrix::Matrix<float>& input);
 
-    // Reset the hidden state (e.g., at the start of a new sequence)
+    /**
+     * @brief Resets the hidden state to all zeros.
+     */
     void ResetState();
 
-    // Getters for weights and biases
+    /** @brief Returns the input-to-hidden weights. */
     Matrix::Matrix<float>& GetW_xh() { return W_xh; }
+
+    /** @brief Returns the hidden-to-hidden weights. */
     Matrix::Matrix<float>& GetW_hh() { return W_hh; }
+
+    /** @brief Returns the hidden bias vector. */
     Matrix::Matrix<float>& Getb_h() { return b_h; }
+
+    /** @brief Returns a copy of the current hidden state. */
     Matrix::Matrix<float> GetHiddenState() const { return h_prev; }
 
 private:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ include(GoogleTest)
 # Define the test executable
 add_executable(runTests
     test_neuronet.cpp
+    test_rnn_layer.cpp
     test_genetic_algorithm.cpp
     test_json.cpp
     test_vocabulary.cpp

--- a/tests/test_rnn_layer.cpp
+++ b/tests/test_rnn_layer.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <stdexcept>
 #include "../src/neural_network/rnn_layer.h"
 
 using namespace NeuroNet;
@@ -15,6 +16,13 @@ TEST(RNNLayerTest, Initialization) {
     EXPECT_EQ(rnn.GetHiddenState().cols(), 20);
 }
 
+TEST(RNNLayerTest, RejectsInvalidDimensions) {
+    EXPECT_THROW(RNNLayer(0, 20), std::invalid_argument);
+    EXPECT_THROW(RNNLayer(10, 0), std::invalid_argument);
+    EXPECT_THROW(RNNLayer(-1, 20), std::invalid_argument);
+    EXPECT_THROW(RNNLayer(10, -1), std::invalid_argument);
+}
+
 TEST(RNNLayerTest, ForwardPass) {
     RNNLayer rnn(5, 10);
     Matrix::Matrix<float> input(1, 5);
@@ -25,8 +33,21 @@ TEST(RNNLayerTest, ForwardPass) {
     EXPECT_EQ(output.cols(), 10);
 }
 
+TEST(RNNLayerTest, RejectsInvalidInputShape) {
+    RNNLayer rnn(5, 10);
+    Matrix::Matrix<float> wrong_columns(1, 4);
+    Matrix::Matrix<float> wrong_rows(2, 5);
+
+    EXPECT_THROW(rnn.Forward(wrong_columns), std::invalid_argument);
+    EXPECT_THROW(rnn.Forward(wrong_rows), std::invalid_argument);
+}
+
 TEST(RNNLayerTest, ResetState) {
     RNNLayer rnn(5, 10);
+    rnn.GetW_xh().assign(0.25f);
+    rnn.GetW_hh().assign(0.0f);
+    rnn.Getb_h().assign(0.0f);
+
     Matrix::Matrix<float> input(1, 5);
     input.assign(1.0f);
 
@@ -34,8 +55,9 @@ TEST(RNNLayerTest, ResetState) {
 
     // Check that state is not all zeros
     bool has_non_zero = false;
-    for(size_t c = 0; c < rnn.GetHiddenState().cols(); ++c) {
-        if(rnn.GetHiddenState()[0][c] != 0.0f) {
+    Matrix::Matrix<float> state = rnn.GetHiddenState();
+    for(size_t c = 0; c < state.cols(); ++c) {
+        if(state[0][c] != 0.0f) {
             has_non_zero = true;
             break;
         }
@@ -46,7 +68,8 @@ TEST(RNNLayerTest, ResetState) {
     rnn.ResetState();
 
     // Check that state is all zeros again
-    for(size_t c = 0; c < rnn.GetHiddenState().cols(); ++c) {
-        EXPECT_FLOAT_EQ(rnn.GetHiddenState()[0][c], 0.0f);
+    state = rnn.GetHiddenState();
+    for(size_t c = 0; c < state.cols(); ++c) {
+        EXPECT_FLOAT_EQ(state[0][c], 0.0f);
     }
 }

--- a/tests/test_rnn_layer.cpp
+++ b/tests/test_rnn_layer.cpp
@@ -1,0 +1,52 @@
+#include <gtest/gtest.h>
+#include "../src/neural_network/rnn_layer.h"
+
+using namespace NeuroNet;
+
+TEST(RNNLayerTest, Initialization) {
+    RNNLayer rnn(10, 20);
+    EXPECT_EQ(rnn.GetW_xh().rows(), 10);
+    EXPECT_EQ(rnn.GetW_xh().cols(), 20);
+    EXPECT_EQ(rnn.GetW_hh().rows(), 20);
+    EXPECT_EQ(rnn.GetW_hh().cols(), 20);
+    EXPECT_EQ(rnn.Getb_h().rows(), 1);
+    EXPECT_EQ(rnn.Getb_h().cols(), 20);
+    EXPECT_EQ(rnn.GetHiddenState().rows(), 1);
+    EXPECT_EQ(rnn.GetHiddenState().cols(), 20);
+}
+
+TEST(RNNLayerTest, ForwardPass) {
+    RNNLayer rnn(5, 10);
+    Matrix::Matrix<float> input(1, 5);
+    input.assign(1.0f);
+
+    Matrix::Matrix<float> output = rnn.Forward(input);
+    EXPECT_EQ(output.rows(), 1);
+    EXPECT_EQ(output.cols(), 10);
+}
+
+TEST(RNNLayerTest, ResetState) {
+    RNNLayer rnn(5, 10);
+    Matrix::Matrix<float> input(1, 5);
+    input.assign(1.0f);
+
+    rnn.Forward(input);
+
+    // Check that state is not all zeros
+    bool has_non_zero = false;
+    for(size_t c = 0; c < rnn.GetHiddenState().cols(); ++c) {
+        if(rnn.GetHiddenState()[0][c] != 0.0f) {
+            has_non_zero = true;
+            break;
+        }
+    }
+    // We expect the state to change after forward pass
+    EXPECT_TRUE(has_non_zero);
+
+    rnn.ResetState();
+
+    // Check that state is all zeros again
+    for(size_t c = 0; c < rnn.GetHiddenState().cols(); ++c) {
+        EXPECT_FLOAT_EQ(rnn.GetHiddenState()[0][c], 0.0f);
+    }
+}


### PR DESCRIPTION
## Summary
- Add a basic `RNNLayer` with tanh hidden-state updates for single-step recurrent processing.
- Register the new source and tests in CMake.
- Reject invalid RNN dimensions before matrix allocation and reject invalid input shapes.
- Add deterministic RNN unit coverage and Doxygen comments for the new public class.
- Update `TODO.MD` to mark basic RNN layer support complete while leaving LSTM support open.

## Validation
- Local: `cmake -B build -DCMAKE_BUILD_TYPE=Release` with Python 3.11 pinned for pybind11.
- Local: `cmake --build build --config Release`.
- Local: `ctest -C Release --output-on-failure` from the build directory, 319/319 passing.
- GitHub: CMake build and Doxygen checks green on rebased head `ddae7bd`.

---
*PR created automatically by Jules for task [6176711644791815170](https://jules.google.com/task/6176711644791815170) started by @JacobBorden*