### PR TITLE
Update changelog for RNN layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Release packaging support for DEB, RPM, and TGZ artifacts through CPack and a published-release GitHub Actions workflow.
 - `pyneuronet` Python bindings for core matrix and neural-network APIs, including CTest-covered binding smoke tests and install packaging for the extension module.
 - Transformer decoder layers and a full encoder-decoder model, including default causal decoder self-attention masking and regression coverage for future-token leakage.
+- Basic `RNNLayer` support with dimension validation, Doxygen comments, CMake wiring, and deterministic unit coverage.
 - Thread-safe `Logger` utility with configurable debug/info/warning/error levels, output redirection, and unit coverage.
 - `MNISTLoader` for standard IDX image and label files, including regression coverage for truncated payloads.
 - `NeuralPathfinder` tests covering empty networks, single-layer networks, multi-layer path selection, and all-zero weights.


### PR DESCRIPTION
## Summary
- Add an Unreleased changelog entry for the merged basic `RNNLayer` support from #140.

## Validation
- Docs-only change; no local CMake/CTest run.

Steward follow-up: this PR is intentionally left open for a later steward run to review and merge after GitHub checks pass.