### PR TITLE
feat: Add Long Short-Term Memory (LSTM) recurrent layers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 add_library(neuronet STATIC 
     src/neural_network/neuronet.cpp
     src/neural_network/rnn_layer.cpp
+    src/neural_network/lstm_layer.cpp
     src/optimization/genetic_algorithm.cpp
     src/optimization/neural_pathfinder.cpp
     src/utilities/json/json.cpp

--- a/TODO.MD
+++ b/TODO.MD
@@ -4,7 +4,7 @@
 - [ ] Implement Backpropagation algorithm as an alternative to Genetic Algorithm for training.
 - [ ] Add support for Convolutional Neural Networks (CNNs).
 - [x] Add basic Recurrent Neural Network (RNN) layer support.
-- [ ] Add support for Long Short-Term Memory (LSTM) recurrent layers.
+- [x] Add support for Long Short-Term Memory (LSTM) recurrent layers.
 - [x] Optimize memory allocation during Matrix operations (e.g. avoid copies).
 - [x] Implement better OpenMP parallelization in Neural Network forward pass, not just Matrix multiplication.
 - [x] Create a Python binding / API for the library (e.g., using pybind11).

--- a/src/neural_network/lstm_layer.cpp
+++ b/src/neural_network/lstm_layer.cpp
@@ -1,0 +1,95 @@
+#include "lstm_layer.h"
+#include <cmath> // For std::tanh, std::exp
+#include <stdexcept>
+
+namespace NeuroNet {
+
+float LSTMLayer::sigmoid(float x) {
+    return 1.0f / (1.0f + std::exp(-x));
+}
+
+LSTMLayer::LSTMLayer(int input_size, int hidden_size)
+    : input_size_(input_size), hidden_size_(hidden_size) {
+    if (input_size_ <= 0 || hidden_size_ <= 0) {
+        throw std::invalid_argument("LSTMLayer dimensions must be positive.");
+    }
+
+    // Initialize forget gate weights and biases
+    W_xf.resize(input_size_, hidden_size_); W_xf.Randomize();
+    W_hf.resize(hidden_size_, hidden_size_); W_hf.Randomize();
+    b_f.resize(1, hidden_size_); b_f.assign(1.0f); // Common to initialize forget gate bias to 1
+
+    // Initialize input gate weights and biases
+    W_xi.resize(input_size_, hidden_size_); W_xi.Randomize();
+    W_hi.resize(hidden_size_, hidden_size_); W_hi.Randomize();
+    b_i.resize(1, hidden_size_); b_i.assign(0.0f);
+
+    // Initialize cell gate (candidate) weights and biases
+    W_xc.resize(input_size_, hidden_size_); W_xc.Randomize();
+    W_hc.resize(hidden_size_, hidden_size_); W_hc.Randomize();
+    b_c.resize(1, hidden_size_); b_c.assign(0.0f);
+
+    // Initialize output gate weights and biases
+    W_xo.resize(input_size_, hidden_size_); W_xo.Randomize();
+    W_ho.resize(hidden_size_, hidden_size_); W_ho.Randomize();
+    b_o.resize(1, hidden_size_); b_o.assign(0.0f);
+
+    // Initialize states
+    h_prev.resize(1, hidden_size_); h_prev.assign(0.0f);
+    c_prev.resize(1, hidden_size_); c_prev.assign(0.0f);
+}
+
+Matrix::Matrix<float> LSTMLayer::Forward(const Matrix::Matrix<float>& input) {
+    if (input.rows() != 1 || input.cols() != static_cast<size_t>(input_size_)) {
+        throw std::invalid_argument("Input size mismatch in LSTMLayer.");
+    }
+
+    // 1. Forget Gate: f_t = sigmoid(W_xf * x_t + W_hf * h_{t-1} + b_f)
+    Matrix::Matrix<float> f_t = (input * W_xf) + (h_prev * W_hf) + b_f;
+    for (size_t c = 0; c < f_t.cols(); ++c) {
+        f_t[0][c] = sigmoid(f_t[0][c]);
+    }
+
+    // 2. Input Gate: i_t = sigmoid(W_xi * x_t + W_hi * h_{t-1} + b_i)
+    Matrix::Matrix<float> i_t = (input * W_xi) + (h_prev * W_hi) + b_i;
+    for (size_t c = 0; c < i_t.cols(); ++c) {
+        i_t[0][c] = sigmoid(i_t[0][c]);
+    }
+
+    // 3. Cell Gate (Candidate): c_tilde_t = tanh(W_xc * x_t + W_hc * h_{t-1} + b_c)
+    Matrix::Matrix<float> c_tilde_t = (input * W_xc) + (h_prev * W_hc) + b_c;
+    for (size_t c = 0; c < c_tilde_t.cols(); ++c) {
+        c_tilde_t[0][c] = std::tanh(c_tilde_t[0][c]);
+    }
+
+    // 4. Output Gate: o_t = sigmoid(W_xo * x_t + W_ho * h_{t-1} + b_o)
+    Matrix::Matrix<float> o_t = (input * W_xo) + (h_prev * W_ho) + b_o;
+    for (size_t c = 0; c < o_t.cols(); ++c) {
+        o_t[0][c] = sigmoid(o_t[0][c]);
+    }
+
+    // 5. Update Cell State: c_t = f_t * c_{t-1} + i_t * c_tilde_t (element-wise multiplication)
+    Matrix::Matrix<float> c_t(1, hidden_size_);
+    for (size_t c = 0; c < c_t.cols(); ++c) {
+        c_t[0][c] = f_t[0][c] * c_prev[0][c] + i_t[0][c] * c_tilde_t[0][c];
+    }
+
+    // 6. Update Hidden State: h_t = o_t * tanh(c_t) (element-wise multiplication)
+    Matrix::Matrix<float> h_t(1, hidden_size_);
+    for (size_t c = 0; c < h_t.cols(); ++c) {
+        h_t[0][c] = o_t[0][c] * std::tanh(c_t[0][c]);
+    }
+
+    // Save states for next step
+    c_prev = c_t;
+    h_prev = h_t;
+
+    return h_t;
+}
+
+void LSTMLayer::ResetState() {
+    h_prev.assign(0.0f);
+    c_prev.assign(0.0f);
+}
+
+} // namespace NeuroNet

--- a/src/neural_network/lstm_layer.h
+++ b/src/neural_network/lstm_layer.h
@@ -1,0 +1,88 @@
+#pragma once
+#include "../math/matrix.h"
+
+namespace NeuroNet {
+
+/**
+ * @brief Long Short-Term Memory (LSTM) recurrent layer.
+ *
+ * LSTMLayer processes one time step at a time. Each forward pass combines the
+ * input with the previous hidden state and cell state, updating and storing them
+ * for the next call.
+ */
+class LSTMLayer {
+public:
+    /**
+     * @brief Constructs an LSTM layer.
+     * @param input_size Number of input features per time step. Must be positive.
+     * @param hidden_size Number of hidden units. Must be positive.
+     * @throws std::invalid_argument if either dimension is non-positive.
+     */
+    LSTMLayer(int input_size, int hidden_size);
+
+    /**
+     * @brief Runs the layer for a single time step.
+     * @param input A 1 x input_size matrix containing the time-step input.
+     * @return The updated 1 x hidden_size hidden state.
+     * @throws std::invalid_argument if input dimensions do not match the layer.
+     */
+    Matrix::Matrix<float> Forward(const Matrix::Matrix<float>& input);
+
+    /**
+     * @brief Resets the hidden and cell states to all zeros.
+     */
+    void ResetState();
+
+    // Getters for states
+    Matrix::Matrix<float> GetHiddenState() const { return h_prev; }
+    Matrix::Matrix<float> GetCellState() const { return c_prev; }
+
+    // Getters for weights and biases
+    Matrix::Matrix<float>& GetW_xf() { return W_xf; }
+    Matrix::Matrix<float>& GetW_hf() { return W_hf; }
+    Matrix::Matrix<float>& Getb_f() { return b_f; }
+
+    Matrix::Matrix<float>& GetW_xi() { return W_xi; }
+    Matrix::Matrix<float>& GetW_hi() { return W_hi; }
+    Matrix::Matrix<float>& Getb_i() { return b_i; }
+
+    Matrix::Matrix<float>& GetW_xc() { return W_xc; }
+    Matrix::Matrix<float>& GetW_hc() { return W_hc; }
+    Matrix::Matrix<float>& Getb_c() { return b_c; }
+
+    Matrix::Matrix<float>& GetW_xo() { return W_xo; }
+    Matrix::Matrix<float>& GetW_ho() { return W_ho; }
+    Matrix::Matrix<float>& Getb_o() { return b_o; }
+
+private:
+    int input_size_;
+    int hidden_size_;
+
+    // Forget gate
+    Matrix::Matrix<float> W_xf;
+    Matrix::Matrix<float> W_hf;
+    Matrix::Matrix<float> b_f;
+
+    // Input gate
+    Matrix::Matrix<float> W_xi;
+    Matrix::Matrix<float> W_hi;
+    Matrix::Matrix<float> b_i;
+
+    // Cell gate (candidate)
+    Matrix::Matrix<float> W_xc;
+    Matrix::Matrix<float> W_hc;
+    Matrix::Matrix<float> b_c;
+
+    // Output gate
+    Matrix::Matrix<float> W_xo;
+    Matrix::Matrix<float> W_ho;
+    Matrix::Matrix<float> b_o;
+
+    Matrix::Matrix<float> h_prev; // Previous hidden state
+    Matrix::Matrix<float> c_prev; // Previous cell state
+
+    // Helper functions for activations
+    float sigmoid(float x);
+};
+
+} // namespace NeuroNet

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ include(GoogleTest)
 add_executable(runTests
     test_neuronet.cpp
     test_rnn_layer.cpp
+    test_lstm_layer.cpp
     test_genetic_algorithm.cpp
     test_json.cpp
     test_vocabulary.cpp

--- a/tests/test_lstm_layer.cpp
+++ b/tests/test_lstm_layer.cpp
@@ -1,0 +1,77 @@
+#include <gtest/gtest.h>
+#include <stdexcept>
+#include "../src/neural_network/lstm_layer.h"
+
+using namespace NeuroNet;
+
+TEST(LSTMLayerTest, Initialization) {
+    LSTMLayer lstm(10, 20);
+    EXPECT_EQ(lstm.GetW_xf().rows(), 10);
+    EXPECT_EQ(lstm.GetW_xf().cols(), 20);
+    EXPECT_EQ(lstm.GetW_hf().rows(), 20);
+    EXPECT_EQ(lstm.GetW_hf().cols(), 20);
+    EXPECT_EQ(lstm.Getb_f().rows(), 1);
+    EXPECT_EQ(lstm.Getb_f().cols(), 20);
+    EXPECT_EQ(lstm.GetHiddenState().rows(), 1);
+    EXPECT_EQ(lstm.GetHiddenState().cols(), 20);
+    EXPECT_EQ(lstm.GetCellState().rows(), 1);
+    EXPECT_EQ(lstm.GetCellState().cols(), 20);
+}
+
+TEST(LSTMLayerTest, RejectsInvalidDimensions) {
+    EXPECT_THROW(LSTMLayer(0, 20), std::invalid_argument);
+    EXPECT_THROW(LSTMLayer(10, 0), std::invalid_argument);
+    EXPECT_THROW(LSTMLayer(-1, 20), std::invalid_argument);
+    EXPECT_THROW(LSTMLayer(10, -1), std::invalid_argument);
+}
+
+TEST(LSTMLayerTest, ForwardPass) {
+    LSTMLayer lstm(5, 10);
+    Matrix::Matrix<float> input(1, 5);
+    input.assign(1.0f);
+
+    Matrix::Matrix<float> output = lstm.Forward(input);
+    EXPECT_EQ(output.rows(), 1);
+    EXPECT_EQ(output.cols(), 10);
+}
+
+TEST(LSTMLayerTest, RejectsInvalidInputShape) {
+    LSTMLayer lstm(5, 10);
+    Matrix::Matrix<float> wrong_columns(1, 4);
+    Matrix::Matrix<float> wrong_rows(2, 5);
+
+    EXPECT_THROW(lstm.Forward(wrong_columns), std::invalid_argument);
+    EXPECT_THROW(lstm.Forward(wrong_rows), std::invalid_argument);
+}
+
+TEST(LSTMLayerTest, ResetState) {
+    LSTMLayer lstm(5, 10);
+    lstm.GetW_xf().assign(0.25f);
+    lstm.GetW_hf().assign(0.0f);
+    lstm.Getb_f().assign(0.0f);
+
+    Matrix::Matrix<float> input(1, 5);
+    input.assign(1.0f);
+
+    lstm.Forward(input);
+
+    // Check that state is not all zeros
+    bool has_non_zero = false;
+    Matrix::Matrix<float> state = lstm.GetHiddenState();
+    for(size_t c = 0; c < state.cols(); ++c) {
+        if(state[0][c] != 0.0f) {
+            has_non_zero = true;
+            break;
+        }
+    }
+    // We expect the state to change after forward pass
+    EXPECT_TRUE(has_non_zero);
+
+    lstm.ResetState();
+
+    // Check that state is all zeros again
+    state = lstm.GetHiddenState();
+    for(size_t c = 0; c < state.cols(); ++c) {
+        EXPECT_FLOAT_EQ(state[0][c], 0.0f);
+    }
+}


### PR DESCRIPTION
This PR implements Long Short-Term Memory (LSTM) recurrent layers as per the TODO.MD file.

- `LSTMLayer` class implemented in `src/neural_network/lstm_layer.h` and `.cpp`
- Implemented standard LSTM forward pass algorithms (f, i, c, and o gates).
- Added comprehensive unit testing for initialization, forward pass, error handling and state reset.
- Updated `CMakeLists.txt` for main project and test configurations.
- Checked off the corresponding item in `TODO.MD`.

---
*PR created automatically by Jules for task [6660334260915562228](https://jules.google.com/task/6660334260915562228) started by @JacobBorden*