### PR TITLE
Update changelog for LSTM layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - `pyneuronet` Python bindings for core matrix and neural-network APIs, including CTest-covered binding smoke tests and install packaging for the extension module.
 - Transformer decoder layers and a full encoder-decoder model, including default causal decoder self-attention masking and regression coverage for future-token leakage.
 - Basic `RNNLayer` support with dimension validation, Doxygen comments, CMake wiring, and deterministic unit coverage.
+- `LSTMLayer` support with gate-state implementation, CMake wiring, TODO update, and unit coverage for initialization, input validation, forward pass, and state reset.
 - Thread-safe `Logger` utility with configurable debug/info/warning/error levels, output redirection, and unit coverage.
 - `MNISTLoader` for standard IDX image and label files, including regression coverage for truncated payloads.
 - `NeuralPathfinder` tests covering empty networks, single-layer networks, multi-layer path selection, and all-zero weights.


### PR DESCRIPTION
## Summary
- Add an Unreleased changelog entry for the merged `LSTMLayer` support from #143.

## Validation
- Docs-only change; no local CMake/CTest run.

Steward follow-up: this PR is intentionally left open for a later steward run to review and merge after GitHub checks pass.