### PR TITLE
✨ feat: Add Convolutional Neural Network (CNN) Layer Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(neuronet STATIC
     src/neural_network/neuronet.cpp
     src/neural_network/rnn_layer.cpp
     src/neural_network/lstm_layer.cpp
+    src/neural_network/conv2d_layer.cpp
     src/optimization/genetic_algorithm.cpp
     src/optimization/neural_pathfinder.cpp
     src/utilities/json/json.cpp

--- a/TODO.MD
+++ b/TODO.MD
@@ -2,7 +2,7 @@
 
 - [x] Add more activation functions (e.g., Sigmoid, Tanh, Swish).
 - [ ] Implement Backpropagation algorithm as an alternative to Genetic Algorithm for training.
-- [ ] Add support for Convolutional Neural Networks (CNNs).
+- [x] Add support for Convolutional Neural Networks (CNNs).
 - [x] Add basic Recurrent Neural Network (RNN) layer support.
 - [x] Add support for Long Short-Term Memory (LSTM) recurrent layers.
 - [x] Optimize memory allocation during Matrix operations (e.g. avoid copies).

--- a/src/neural_network/conv2d_layer.cpp
+++ b/src/neural_network/conv2d_layer.cpp
@@ -16,11 +16,19 @@ Conv2DLayer::Conv2DLayer(int input_channels, int output_channels, int kernel_siz
 }
 
 int Conv2DLayer::GetOutputHeight(int input_height) const {
-    return (input_height + 2 * padding_ - kernel_size_) / stride_ + 1;
+    const int effective_height = input_height + 2 * padding_;
+    if (input_height <= 0 || effective_height < kernel_size_) {
+        return 0;
+    }
+    return (effective_height - kernel_size_) / stride_ + 1;
 }
 
 int Conv2DLayer::GetOutputWidth(int input_width) const {
-    return (input_width + 2 * padding_ - kernel_size_) / stride_ + 1;
+    const int effective_width = input_width + 2 * padding_;
+    if (input_width <= 0 || effective_width < kernel_size_) {
+        return 0;
+    }
+    return (effective_width - kernel_size_) / stride_ + 1;
 }
 
 Matrix::Matrix<float> Conv2DLayer::Forward(const Matrix::Matrix<float>& input, int input_height, int input_width) {
@@ -29,7 +37,8 @@ Matrix::Matrix<float> Conv2DLayer::Forward(const Matrix::Matrix<float>& input, i
     if (out_h <= 0 || out_w <= 0) {
         throw std::invalid_argument("Invalid output dimensions in Conv2DLayer");
     }
-    if (static_cast<int>(input.cols()) != input_channels_ * input_height * input_width) {
+    if (input.rows() != 1 ||
+        static_cast<int>(input.cols()) != input_channels_ * input_height * input_width) {
         throw std::invalid_argument("Invalid input dimensions in Conv2DLayer");
     }
 

--- a/src/neural_network/conv2d_layer.cpp
+++ b/src/neural_network/conv2d_layer.cpp
@@ -1,0 +1,65 @@
+#include "conv2d_layer.h"
+#include <stdexcept>
+#include <cmath>
+
+namespace NeuroNet {
+
+Conv2DLayer::Conv2DLayer(int input_channels, int output_channels, int kernel_size, int stride, int padding)
+    : input_channels_(input_channels), output_channels_(output_channels), kernel_size_(kernel_size), stride_(stride), padding_(padding) {
+    if (input_channels <= 0 || output_channels <= 0 || kernel_size <= 0 || stride <= 0 || padding < 0) {
+        throw std::invalid_argument("Invalid arguments for Conv2DLayer");
+    }
+    filters_.resize(output_channels, input_channels * kernel_size * kernel_size);
+    filters_.Randomize();
+    biases_.resize(1, output_channels);
+    biases_.assign(0.0f);
+}
+
+int Conv2DLayer::GetOutputHeight(int input_height) const {
+    return (input_height + 2 * padding_ - kernel_size_) / stride_ + 1;
+}
+
+int Conv2DLayer::GetOutputWidth(int input_width) const {
+    return (input_width + 2 * padding_ - kernel_size_) / stride_ + 1;
+}
+
+Matrix::Matrix<float> Conv2DLayer::Forward(const Matrix::Matrix<float>& input, int input_height, int input_width) {
+    int out_h = GetOutputHeight(input_height);
+    int out_w = GetOutputWidth(input_width);
+    if (out_h <= 0 || out_w <= 0) {
+        throw std::invalid_argument("Invalid output dimensions in Conv2DLayer");
+    }
+    if (static_cast<int>(input.cols()) != input_channels_ * input_height * input_width) {
+        throw std::invalid_argument("Invalid input dimensions in Conv2DLayer");
+    }
+
+    Matrix::Matrix<float> output(1, output_channels_ * out_h * out_w);
+    output.assign(0.0f);
+
+    for (int oc = 0; oc < output_channels_; ++oc) {
+        for (int oh = 0; oh < out_h; ++oh) {
+            for (int ow = 0; ow < out_w; ++ow) {
+                float val = 0.0f;
+                for (int ic = 0; ic < input_channels_; ++ic) {
+                    for (int kh = 0; kh < kernel_size_; ++kh) {
+                        for (int kw = 0; kw < kernel_size_; ++kw) {
+                            int ih = oh * stride_ - padding_ + kh;
+                            int iw = ow * stride_ - padding_ + kw;
+                            if (ih >= 0 && ih < input_height && iw >= 0 && iw < input_width) {
+                                int input_idx = ic * (input_height * input_width) + ih * input_width + iw;
+                                int filter_idx = ic * (kernel_size_ * kernel_size_) + kh * kernel_size_ + kw;
+                                val += input[0][input_idx] * filters_[oc][filter_idx];
+                            }
+                        }
+                    }
+                }
+                val += biases_[0][oc];
+                int out_idx = oc * (out_h * out_w) + oh * out_w + ow;
+                output[0][out_idx] = val;
+            }
+        }
+    }
+    return output;
+}
+
+} // namespace NeuroNet

--- a/src/neural_network/conv2d_layer.h
+++ b/src/neural_network/conv2d_layer.h
@@ -3,11 +3,40 @@
 
 namespace NeuroNet {
 
+/**
+ * @brief A single-sample 2D convolution layer for flattened image inputs.
+ */
 class Conv2DLayer {
 public:
+    /**
+     * @brief Creates a convolution layer with square kernels.
+     *
+     * @param input_channels Number of channels in the flattened input image.
+     * @param output_channels Number of convolution filters to apply.
+     * @param kernel_size Width and height of each square kernel.
+     * @param stride Convolution stride in both spatial dimensions.
+     * @param padding Zero-padding applied around the input image.
+     */
     Conv2DLayer(int input_channels, int output_channels, int kernel_size, int stride = 1, int padding = 0);
+
+    /**
+     * @brief Applies the layer to one flattened image.
+     *
+     * @param input Matrix with exactly one row containing channel-major flattened image data.
+     * @param input_height Height of the unflattened input image.
+     * @param input_width Width of the unflattened input image.
+     * @return A single-row matrix containing flattened channel-major output feature maps.
+     */
     Matrix::Matrix<float> Forward(const Matrix::Matrix<float>& input, int input_height, int input_width);
+
+    /**
+     * @brief Computes the output feature-map height for a given input height.
+     */
     int GetOutputHeight(int input_height) const;
+
+    /**
+     * @brief Computes the output feature-map width for a given input width.
+     */
     int GetOutputWidth(int input_width) const;
 private:
     int input_channels_;

--- a/src/neural_network/conv2d_layer.h
+++ b/src/neural_network/conv2d_layer.h
@@ -1,0 +1,22 @@
+#pragma once
+#include "../math/matrix.h"
+
+namespace NeuroNet {
+
+class Conv2DLayer {
+public:
+    Conv2DLayer(int input_channels, int output_channels, int kernel_size, int stride = 1, int padding = 0);
+    Matrix::Matrix<float> Forward(const Matrix::Matrix<float>& input, int input_height, int input_width);
+    int GetOutputHeight(int input_height) const;
+    int GetOutputWidth(int input_width) const;
+private:
+    int input_channels_;
+    int output_channels_;
+    int kernel_size_;
+    int stride_;
+    int padding_;
+    Matrix::Matrix<float> filters_;
+    Matrix::Matrix<float> biases_;
+};
+
+} // namespace NeuroNet

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(runTests
     test_neuronet.cpp
     test_rnn_layer.cpp
     test_lstm_layer.cpp
+    test_conv2d_layer.cpp
     test_genetic_algorithm.cpp
     test_json.cpp
     test_vocabulary.cpp

--- a/tests/test_conv2d_layer.cpp
+++ b/tests/test_conv2d_layer.cpp
@@ -22,6 +22,29 @@ TEST(Conv2DLayerTest, OutputDimensions) {
     Conv2DLayer layer_stride(1, 1, 3, 2, 0);
     EXPECT_EQ(layer_stride.GetOutputHeight(5), 2);
     EXPECT_EQ(layer_stride.GetOutputWidth(5), 2);
+
+    Conv2DLayer layer_large_kernel(1, 1, 5, 4, 0);
+    EXPECT_EQ(layer_large_kernel.GetOutputHeight(2), 0);
+    EXPECT_EQ(layer_large_kernel.GetOutputWidth(2), 0);
+}
+
+TEST(Conv2DLayerTest, ForwardThrowsWhenKernelDoesNotFitInput) {
+    Conv2DLayer layer(1, 1, 5, 4, 0);
+    Matrix::Matrix<float> input(1, 4);
+    input.assign(1.0f);
+
+    EXPECT_THROW(layer.Forward(input, 2, 2), std::invalid_argument);
+}
+
+TEST(Conv2DLayerTest, ForwardRequiresSingleFlattenedInputRow) {
+    Conv2DLayer layer(1, 1, 3, 1, 0);
+
+    Matrix::Matrix<float> batched_input(2, 9);
+    batched_input.assign(1.0f);
+    EXPECT_THROW(layer.Forward(batched_input, 3, 3), std::invalid_argument);
+
+    Matrix::Matrix<float> empty_input(0, 9);
+    EXPECT_THROW(layer.Forward(empty_input, 3, 3), std::invalid_argument);
 }
 
 TEST(Conv2DLayerTest, ForwardPass) {

--- a/tests/test_conv2d_layer.cpp
+++ b/tests/test_conv2d_layer.cpp
@@ -1,0 +1,36 @@
+#include <gtest/gtest.h>
+#include "../src/neural_network/conv2d_layer.h"
+
+using namespace NeuroNet;
+
+TEST(Conv2DLayerTest, Initialization) {
+    EXPECT_NO_THROW(Conv2DLayer(1, 1, 3));
+    EXPECT_THROW(Conv2DLayer(0, 1, 3), std::invalid_argument);
+    EXPECT_THROW(Conv2DLayer(1, 0, 3), std::invalid_argument);
+    EXPECT_THROW(Conv2DLayer(1, 1, 0), std::invalid_argument);
+}
+
+TEST(Conv2DLayerTest, OutputDimensions) {
+    Conv2DLayer layer(1, 1, 3, 1, 0);
+    EXPECT_EQ(layer.GetOutputHeight(5), 3);
+    EXPECT_EQ(layer.GetOutputWidth(5), 3);
+
+    Conv2DLayer layer_pad(1, 1, 3, 1, 1);
+    EXPECT_EQ(layer_pad.GetOutputHeight(5), 5);
+    EXPECT_EQ(layer_pad.GetOutputWidth(5), 5);
+
+    Conv2DLayer layer_stride(1, 1, 3, 2, 0);
+    EXPECT_EQ(layer_stride.GetOutputHeight(5), 2);
+    EXPECT_EQ(layer_stride.GetOutputWidth(5), 2);
+}
+
+TEST(Conv2DLayerTest, ForwardPass) {
+    Conv2DLayer layer(1, 1, 2, 1, 0); // 1 in_channel, 1 out_channel, 2x2 kernel
+    // Create a 3x3 input matrix (1 channel, flattened)
+    Matrix::Matrix<float> input(1, 9);
+    for (int i = 0; i < 9; ++i) input[0][i] = 1.0f;
+
+    Matrix::Matrix<float> output = layer.Forward(input, 3, 3);
+    EXPECT_EQ(output.rows(), 1);
+    EXPECT_EQ(output.cols(), 4); // 2x2 output flattened
+}


### PR DESCRIPTION
This PR implements a basic Convolutional Neural Network (CNN) layer (`Conv2DLayer`) and checks off the corresponding pending issue in the `TODO.MD` list.

**Changes:**
1.  **Added `Conv2DLayer`:** Created a new layer class in `src/neural_network/conv2d_layer.h` and `.cpp` that supports 2D convolutions with customizable `input_channels`, `output_channels`, `kernel_size`, `stride`, and `padding`.
2.  **Forward Pass:** Implemented the forward pass logic to correctly apply the convolution operation, including handling padded bounds.
3.  **Unit Tests:** Added comprehensive tests in `tests/test_conv2d_layer.cpp` to verify initialization rules, output dimension calculations, invalid input handling, and the forward pass itself.
4.  **Build System Integration:** Updated both the main and test `CMakeLists.txt` files to compile and link the new CNN code.
5.  **Documentation:** Marked the CNN issue as complete `[x]` in `TODO.MD` and documented the new `Conv2DLayer` API with Doxygen comments.

**Steward repair:**
- Rebased onto current `master` after #145 merged.
- Fixed output-size handling when the padded input is smaller than the kernel.
- Required exactly one flattened input row so batched or empty matrices are rejected before reading `input[0]`.

**Validation:**
- `cmake -B build -DCMAKE_BUILD_TYPE=Release -DPython3_EXECUTABLE=/bin/python3.11 -DPython_EXECUTABLE=/bin/python3.11 -DPYTHON_EXECUTABLE=/bin/python3.11`
- `cmake --build build --config Release`
- `ctest -C Release --output-on-failure` (193/193 passed)

---
*PR created automatically by Jules for task [10423663073131487965](https://jules.google.com/task/10423663073131487965) started by @JacobBorden*