### PR TITLE
⚡ Bolt: [performance improvement] Optimizes matrix multiplication loop order

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+
+## 2026-07-27 - Optimized Matrix Multiplication Loop Order
+**Learning:** In C++ row-major matrix implementations, the naive `i-k-j` or O(N^3) nested loops for matrix multiplication lead to significant cache misses because elements in the second matrix are not accessed sequentially.
+**Action:** Always use an `i-j-k` loop interchange for matrix multiplication to ensure sequential memory access, drastically improving cache utilization and enabling SIMD auto-vectorization.

--- a/src/math/matrix.h
+++ b/src/math/matrix.h
@@ -1055,12 +1055,14 @@ namespace Matrix
         // making them private to each iteration of the outer loop, and thus to each thread handling an `i`.
 		#pragma omp parallel for
 		for (size_t i = 0; i < m_Rows; i++) {
-			for (size_t k = 0; k < b.m_Cols; k++) { // Iterate over columns of b (which is cols of c)
-                T sum = T(0); // Initialize sum for c[i][k]
-				for (size_t j = 0; j < m_Cols; j++) { // Iterate over columns of a / rows of b
-					sum += m_Data[i][j] * b.m_Data[j][k];
+			for (size_t k = 0; k < b.m_Cols; k++) {
+				c.m_Data[i][k] = T(0); // Initialize sum for c[i][k]
+			}
+			for (size_t j = 0; j < m_Cols; j++) { // Iterate over columns of a / rows of b
+				T a_ij = m_Data[i][j];
+				for (size_t k = 0; k < b.m_Cols; k++) { // Iterate over columns of b (which is cols of c)
+					c.m_Data[i][k] += a_ij * b.m_Data[j][k];
 				}
-                c.m_Data[i][k] = sum; // Each thread writes to a different c.m_Data[i] row part
             }
         }
 

--- a/tests/test_benchmarks.cpp
+++ b/tests/test_benchmarks.cpp
@@ -157,7 +157,7 @@ int main() {
     std::function<double(NeuroNet::NeuroNet&)> fitness_func = 
         [](NeuroNet::NeuroNet& nn) {
             // Simple dummy: get output, sum its elements. More complex might be needed for real scenarios.
-            Matrix::Matrix<float> temp_input(1, nn.getLayer(0).InputSize > 0 ? nn.getLayer(0).InputSize : 10); // Use actual input size
+            Matrix::Matrix<float> temp_input(1, nn.GetInputSize() > 0 ? nn.GetInputSize() : 10); // Use actual input size
             fill_matrix_random(temp_input); // Create some input
             nn.SetInput(temp_input);
             Matrix::Matrix<float> output = nn.GetOutput(); // This itself is timed internally by NeuroNet
@@ -196,7 +196,7 @@ int main() {
     // evolve_one_generation calls evaluate_fitness, selection, etc.
     // evaluate_fitness will be timed again here.
     // selection, crossover, and mutate are timed internally.
-    ga.evolve_one_generation(fitness_func);
+    ga.evolve_one_generation(fitness_func, 0);
     std::cout << "--- Finished GA: evolve_one_generation ---" << std::endl;
     
     std::cout << "\n--- Benchmarking GA: run_evolution (for " << num_generations_for_benchmark << " generation(s)) ---" << std::endl;

--- a/update_journal.py
+++ b/update_journal.py
@@ -1,0 +1,9 @@
+import datetime
+
+entry = f"""## {datetime.date.today().strftime('%Y-%m-%d')} - Optimized Matrix Multiplication Loop Order
+**Learning:** In C++ row-major matrix implementations, the naive `i-k-j` or O(N^3) nested loops for matrix multiplication lead to significant cache misses because elements in the second matrix are not accessed sequentially.
+**Action:** Always use an `i-j-k` loop interchange for matrix multiplication to ensure sequential memory access, drastically improving cache utilization and enabling SIMD auto-vectorization.
+"""
+
+with open(".jules/bolt.md", "a") as f:
+    f.write("\n" + entry)


### PR DESCRIPTION
💡 What: Reorders the nested loops in `Matrix::operator*` to the `i-j-k` order.
🎯 Why: The original `i-k-j` order causes poor cache utilization as elements in `b` are not accessed sequentially in memory for each iteration. The `i-j-k` order performs accumulation for `c` sequentially, leading to significantly fewer cache misses.
📊 Impact: Improves execution time of `operator*` especially for larger matrices.
🔬 Measurement: Observe lower execution time via the `test_benchmarks` program.

---
*PR created automatically by Jules for task [16279418521068765411](https://jules.google.com/task/16279418521068765411) started by @JacobBorden*