### PR TITLE
⚡ Bolt: [performance improvement] Cache-friendly loop interchange for matrix multiplication

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-08-15 - Matrix Multiplication Cache Locality
+**Learning:** Using an i-k-j naive matrix multiplication loop structure on row-major matrices results in poor cache utilization.
+**Action:** Implement an i-j-k loop interchange for O(N^3) matrix operations to ensure sequential memory access and avoid significant cache misses.

--- a/src/math/matrix.h
+++ b/src/math/matrix.h
@@ -1049,18 +1049,19 @@ namespace Matrix
 		Matrix<T> c(m_Rows, b.m_Cols); // Result matrix initialized to zeros by MatrixRow constructor
         // Parallelize the outermost loop using OpenMP.
         // Requires compiler support for OpenMP (e.g., -fopenmp for GCC/Clang, /openmp for MSVC).
-        // Loop variables i, j, k and sum are private by default in this structure or effectively private.
-        // `i` is the loop control variable for the parallel for.
-        // `k`, `j`, and `sum` are declared inside the scope of the `i` loop,
-        // making them private to each iteration of the outer loop, and thus to each thread handling an `i`.
+        // Uses i-j-k loop interchange for optimal cache locality.
 		#pragma omp parallel for
 		for (size_t i = 0; i < m_Rows; i++) {
-			for (size_t k = 0; k < b.m_Cols; k++) { // Iterate over columns of b (which is cols of c)
-                T sum = T(0); // Initialize sum for c[i][k]
-				for (size_t j = 0; j < m_Cols; j++) { // Iterate over columns of a / rows of b
-					sum += m_Data[i][j] * b.m_Data[j][k];
+            // Initialize result row to 0
+            for (size_t k = 0; k < b.m_Cols; k++) {
+                c.m_Data[i][k] = T(0);
+            }
+            // Loop interchange i-j-k for better cache locality (sequential memory access)
+			for (size_t j = 0; j < m_Cols; j++) {
+                T a_ij = m_Data[i][j];
+				for (size_t k = 0; k < b.m_Cols; k++) {
+					c.m_Data[i][k] += a_ij * b.m_Data[j][k];
 				}
-                c.m_Data[i][k] = sum; // Each thread writes to a different c.m_Data[i] row part
             }
         }
 

--- a/tests/test_benchmarks.cpp
+++ b/tests/test_benchmarks.cpp
@@ -157,7 +157,7 @@ int main() {
     std::function<double(NeuroNet::NeuroNet&)> fitness_func = 
         [](NeuroNet::NeuroNet& nn) {
             // Simple dummy: get output, sum its elements. More complex might be needed for real scenarios.
-            Matrix::Matrix<float> temp_input(1, nn.getLayer(0).InputSize > 0 ? nn.getLayer(0).InputSize : 10); // Use actual input size
+            Matrix::Matrix<float> temp_input(1, nn.GetInputSize() > 0 ? nn.GetInputSize() : 10); // Use actual input size
             fill_matrix_random(temp_input); // Create some input
             nn.SetInput(temp_input);
             Matrix::Matrix<float> output = nn.GetOutput(); // This itself is timed internally by NeuroNet
@@ -196,7 +196,7 @@ int main() {
     // evolve_one_generation calls evaluate_fitness, selection, etc.
     // evaluate_fitness will be timed again here.
     // selection, crossover, and mutate are timed internally.
-    ga.evolve_one_generation(fitness_func);
+    ga.evolve_one_generation(fitness_func, 0);
     std::cout << "--- Finished GA: evolve_one_generation ---" << std::endl;
     
     std::cout << "\n--- Benchmarking GA: run_evolution (for " << num_generations_for_benchmark << " generation(s)) ---" << std::endl;


### PR DESCRIPTION
💡 What: Refactored the nested loop order in `Matrix<T>::operator*` from `i-k-j` to `i-j-k`.
🎯 Why: Matrix elements are stored in row-major order. Iterating across columns in the inner loop (k) ensures we access sequential memory locations, maximizing cache hit rate compared to the previous `i-k-j` implementation.
📊 Impact: Improves matrix multiplication speed (e.g., 500x500 matrix multiplication operations are significantly faster).
🔬 Measurement: Verified using tests and `tests/test_benchmarks.cpp`.

---
*PR created automatically by Jules for task [11303859530249870950](https://jules.google.com/task/11303859530249870950) started by @JacobBorden*