### PR TITLE
⚡ Bolt: Optimized matrix multiplication loop order for better cache locality

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## $(date +%Y-%m-%d) - [Optimize Matrix Multiplication Loop Order]
+**Learning:** Found an i-k-j loop order in the OpenMP parallelized matrix multiplication `operator*` in `src/math/matrix.h`. Because the matrix data is stored in row-major order, accessing `b.m_Data[j][k]` in the innermost loop over `j` causes severe cache thrashing.
+**Action:** Reordered the loops to i-j-k. This ensures that the innermost loop iterates over `k` for both `c.m_Data[i][k]` and `b.m_Data[j][k]`, achieving contiguous memory access and better cache locality. The result initialization `c.m_Data[i][k] = T(0)` was moved to a separate loop inside `i` to accommodate this. Tested to show improved speeds on larger matrices.

--- a/src/math/matrix.h
+++ b/src/math/matrix.h
@@ -1053,14 +1053,17 @@ namespace Matrix
         // `i` is the loop control variable for the parallel for.
         // `k`, `j`, and `sum` are declared inside the scope of the `i` loop,
         // making them private to each iteration of the outer loop, and thus to each thread handling an `i`.
+        // Optimized loop order i-j-k for better cache locality when accessing matrix b in row-major order.
 		#pragma omp parallel for
 		for (size_t i = 0; i < m_Rows; i++) {
-			for (size_t k = 0; k < b.m_Cols; k++) { // Iterate over columns of b (which is cols of c)
-                T sum = T(0); // Initialize sum for c[i][k]
-				for (size_t j = 0; j < m_Cols; j++) { // Iterate over columns of a / rows of b
-					sum += m_Data[i][j] * b.m_Data[j][k];
+            for (size_t k = 0; k < b.m_Cols; k++) {
+                c.m_Data[i][k] = T(0);
+            }
+            for (size_t j = 0; j < m_Cols; j++) { // Iterate over columns of a / rows of b
+                T a_ij = m_Data[i][j];
+                for (size_t k = 0; k < b.m_Cols; k++) { // Iterate over columns of b (which is cols of c)
+					c.m_Data[i][k] += a_ij * b.m_Data[j][k];
 				}
-                c.m_Data[i][k] = sum; // Each thread writes to a different c.m_Data[i] row part
             }
         }
 

--- a/tests/test_benchmarks.cpp
+++ b/tests/test_benchmarks.cpp
@@ -157,7 +157,7 @@ int main() {
     std::function<double(NeuroNet::NeuroNet&)> fitness_func = 
         [](NeuroNet::NeuroNet& nn) {
             // Simple dummy: get output, sum its elements. More complex might be needed for real scenarios.
-            Matrix::Matrix<float> temp_input(1, nn.getLayer(0).InputSize > 0 ? nn.getLayer(0).InputSize : 10); // Use actual input size
+            Matrix::Matrix<float> temp_input(1, nn.GetInputSize() > 0 ? nn.GetInputSize() : 10); // Use actual input size
             fill_matrix_random(temp_input); // Create some input
             nn.SetInput(temp_input);
             Matrix::Matrix<float> output = nn.GetOutput(); // This itself is timed internally by NeuroNet
@@ -196,7 +196,7 @@ int main() {
     // evolve_one_generation calls evaluate_fitness, selection, etc.
     // evaluate_fitness will be timed again here.
     // selection, crossover, and mutate are timed internally.
-    ga.evolve_one_generation(fitness_func);
+    ga.evolve_one_generation(fitness_func, 0);
     std::cout << "--- Finished GA: evolve_one_generation ---" << std::endl;
     
     std::cout << "\n--- Benchmarking GA: run_evolution (for " << num_generations_for_benchmark << " generation(s)) ---" << std::endl;


### PR DESCRIPTION
💡 What: Optimized the matrix multiplication loop order in `src/math/matrix.h` from i-k-j to i-j-k.
🎯 Why: The original i-k-j loop order caused cache thrashing because the inner loop over 'j' accessed elements in 'b' across different rows, which is slow for row-major memory layouts.
📊 Impact: Reduces cache misses and speeds up matrix multiplication, especially for larger matrices.
🔬 Measurement: Can be verified by running the `benchmark_test` executable (compiled from `tests/test_benchmarks.cpp`).

---
*PR created automatically by Jules for task [10642033258345901649](https://jules.google.com/task/10642033258345901649) started by @JacobBorden*